### PR TITLE
Upgrade to zig 0.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-latest, macos-13]
+        os: [windows-2022, ubuntu-latest, macos-13]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Build
       run: bash ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: mlugg/setup-zig@v2.0.5
       with:
-        version:
+        use-cache: false
 
     - name: Build
       run: bash ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  pull-request:
   push:
     branches:
       - master
@@ -16,10 +17,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-latest, macos-13]
+        os: [windows-2022, ubuntu-latest, macos-13]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Build
       run: bash ./scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  pull-request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+    - uses: mlugg/setup-zig@v2.0.5
+      with:
+        version:
+
     - name: Build
       run: bash ./scripts/build.sh
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       
     - name: Validate
       run: |
-        bash ./scripts/validate-clap.sh
+        # bash ./scripts/validate-clap.sh
         bash ./scripts/validate-vst.sh

--- a/README.md
+++ b/README.md
@@ -2,32 +2,6 @@
 
 ## For the future of plugin development
 
-## Goals
-
-* Dead-simple plugin development. Write <= 100 lines of code and have a runnable
-blank-slate plugin.
-
-* Ideally only require Zig as a toolchain dependency, not as a programming
-language. You should be able to write plugins in C/C++/whatever and easily link
-that code to Arbor via a C API and the Zig build system.
-
-	* Could also have a `get_zig.sh` that will download latest stable Zig if you
-	don't already have it
-
-* Easy cross-compilation. Compile to Mac/Linux/Windows from Mac/Linux/Windows,
-batteries included.
-
-* Cross-platform graphics. A simple software renderer (like Olivec), but also
-native graphics programming, potentially using something like [sokol](https://github.com/floooh/sokol.git), or making a thin wrapper around Direct2D/CoreGraphics for
-cross-platform graphics abstraction, giving the programmer a simple choice with
-little-to-no platform-specific considerations.
-
-* Simple, declarative UI design. Possibly with the option of using a custom
-CSS-like syntax (or [Ziggy](https://github.com/kristoff-it/ziggy.git)) to
-declare, arrange, and style UI widgets at **runtime** or **compile-time**, all
-compiling to native code--not running in some god-forsaken web browser embedded
-in a plugin UI 🤮
-
 ## Have:
 
 * A nice abstraction layer over plugin APIs which should lend itself nicely to
@@ -45,6 +19,33 @@ extending support to other APIs
 
 * Simple, portable software rendering using [Olivec](https://github.com/tsoding/olive.c) and a custom
 text rendering function with a bitmap font
+
+## Goals
+
+* Dead-simple plugin development. Write <= 100 lines of code and have a runnable
+blank-slate plugin.
+
+* Easy cross-compilation. Compile to Mac/Linux/Windows from Mac/Linux/Windows,
+batteries included.
+
+* Cross-platform graphics. A simple software renderer (like Olivec),
+but also native graphics programming, potentially using something like
+[sokol](https://github.com/floooh/sokol.git), or making a thin wrapper around
+Direct2D/CoreGraphics for cross-platform graphics abstraction (see `direct2d`
+branch for an early in-progress idea of this), giving the programmer a simple
+choice with little-to-no platform-specific considerations.
+
+* Simple, declarative UI design.
+
+	* Currently working on a custom immediate-mode UI library
+	
+	* Further down the road considering the option of using a custom CSS-like
+	syntax to write stylesheets for UI widgets which can be read at **runtime** or
+	**compiled**, all as native code--not running in some god-forsaken web browser
+	embedded in a plugin UI 🤮. However, this may prove to be too great an abstraction, especially
+	if a flexible IMGUI API can provide a lot of this functionality with stylesheets-as-structs. One
+	option could be to read & watch a config file at runtime which fills out stylesheet data & may be
+	updated whenever the file is changed.
 
 ## TODO:
 
@@ -117,7 +118,31 @@ Run `zig init` to create some boilerplate for a Zig project. Or, create a
 The commit SHA is the SHA of the commit you wish to checkout. You can supply
 `master` instead (not recommended) if you want to pull from the repo's head each time, which is less predictable.
 
-In top-level `build.zig`:
+First, create a `config.zon` which will describe some details about your plugin:
+
+```zon
+.{
+    .description = .{
+        .name = "My Evil Plugin",
+        .id = "com.Plug-O.Evil",
+        .company = "Plug-O Corp, Ltd",
+        .version = "0.1.0",
+        .copyright = "(c) 2024 Plug-O Corp, Ltd",
+        .url = "https://plug-o-corp.biz",
+        .manual = "https://plug-o-corp.biz/Evil/manual.pdf",
+        .contact = "contact@plug-o-corp.biz",
+        .description = "Vintage analog warmth",
+    },
+    .features = .{
+        .stereo = true,
+        .effect = true,
+        .eq = true,
+    },
+    .root_source_file = "plugin.zig",
+}
+```
+
+Now make a `build.zig`:
 
 ```zig
 const std = @import("std");
@@ -128,23 +153,11 @@ pub fn build(b: *std.Build) !void {
 	const optimize = b.standardOptimizeOption(.{});
 
 	try arbor.addPlugin(b, .{
-		.description = .{
-			.id = "com.Plug-O.Evil",
-			.name = "My Evil Plugin",
-			.company = "Plug-O Corp, Ltd.",
-			.version = "0.1.0",
-			.url = "https://plug-o-corp.biz",
-			.contact = "contact@plug-o-corp.biz",
-			.manual = "https://plug-o-corp.biz/Evil/manual.pdf",
-			.copyright = "(c) 2100 Plug-O-Corp, Ltd.",
-			.description = "Vintage Analog Warmth",
-		},
-		.features = arbor.features.STEREO | arbor.features.EFFECT |
-			arbor.features.EQ,
-		.root_source_file = "src/plugin.zig",
+		.plugin_config = @import("config.zon"), // imports your config as data which will be used by the build process
+		.plugin_config_path = b.path("config.zon"), // also requires the path for importing the config later
 		.target = target,
 		.optimize = optimize,
-	});
+	}, &.{.CLAP, .VST2}); // an array of plugin formats
 }
 ```
 
@@ -165,9 +178,9 @@ const params = &[_]arbor.Parameter{
 		0.0, // min
 		10.0, // max
 		0.666, // default
-		.{.flags = .{}}, // can provide additional flags
-	);
-	arbor.param.Choice("Mode", Mode.Vintage, .{.flags = .{}});
+		.{.flags = .{}}, // can provide additional flags, such as text-value/value-text conversion func., & other stuff
+	),
+	arbor.param.Choice("Mode", Mode.Vintage, .{.flags = .{}}),
 };
 
 const Plugin = @This();
@@ -177,18 +190,23 @@ const allocator = std.heap.c_allocator;
 
 // initialize plugin 
 export fn init() *arbor.Plugin {
-	const plugin = arbor.init(allocator, params .{
-		.deinit = deinit,
-		.prepare = prepare,
-		.process = process,
-	});
 	const user_plugin = allocator.create(Plugin) catch |err| // catch any allocation errors
 		arbor.log.fatal("Plugin create failed: {!}\n", .{err}, @src());
-
 	user_plugin.* = .{}; // init our plugin to default
-	plugin.user = user_plugin; // set user context pointer
-		
-	return plugin;
+
+	return arbor.createPlugin(.{
+		.allocator = allocator,
+		.params = params,
+		.num_inputs = 2,
+		.num_outputs = 2,
+		.interface = .{
+			.deinit = deinit,
+			.prepare = prepare,
+			.process = process,
+		},
+		.user_data = user_plugin, // give arbor a pointer to our private plugin data
+	});
+
 }
 
 fn deinit(plugin: *arbor.Plugin) void {
@@ -223,13 +241,11 @@ fn process(plugin: *arbor.Plugin, buffer: arbor.AudioBuffer(f32)) void {
 To build:
 
 ```sh
-zig build
-# Add 'copy' to copy plugin to user plugin dir
+zig build copy
+# Adding 'copy' will copy plugin to user plugin dir
+# Optimization modes: -Doptimize=[Debug/ReleaseSmall/ReleaseSafe/ReleaseFast]
 # Eventual compile options:
-# You can add -Dformat=[VST2/VST3/CLAP/AU]
-# Not providing a format will compile all formats available on your platform
 # Cross compile by adding -Dtarget=[aarch64-macos/x86_64-windows/etc...]
-# Build modes: -Doptimize=[Debug/ReleaseSmall/ReleaseSafe/ReleaseFast]
 ```
 
 ## Acknowledgements

--- a/build.zig
+++ b/build.zig
@@ -1,96 +1,120 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const arbor = @import("src/arbor.zig");
+const arbor = @import("src/plugin_description.zig");
+const PluginConfig = arbor.PluginConfig;
 const Format = arbor.Format;
-const formats = std.enums.values(Format);
-const Description = arbor.Plugin.Description;
-pub const features = arbor.features;
+const all_formats = std.enums.values(Format);
+const Description = arbor.Description;
 
 comptime {
-    if (builtin.zig_version.minor != 13 and
-        builtin.zig_version.patch != 0) @compileError("Requires Zig 0.13 stable");
+    const minor_req = 15;
+    if (builtin.zig_version.minor != minor_req)
+        @compileError(std.fmt.comptimePrint("Requires Zig 0.{d}.x stable", .{minor_req}));
 }
 
 // TODO: Implement a MacOS Universal Binary build mode which will build both archs & lipo
 // TODO: Configure OSX sysroot so we can supply our own SDK
 
+// pub const PluginConfig = struct {
+//     description: Description,
+//     features: arbor.PluginFeatures,
+//     root_source_file: []const u8,
+//     format: []const Format = all_formats,
+
+//     // in-place modification of certain properties
+
+//     pub fn withName(self: PluginConfig, name: [:0]const u8) PluginConfig {
+//         var new = self;
+//         new.description.name = name;
+//         return new;
+//     }
+
+//     pub fn withID(self: PluginConfig, id: [:0]const u8) PluginConfig {
+//         var new = self;
+//         new.description.id = id;
+//         return new;
+//     }
+
+//     pub fn withSource(self: PluginConfig, src: []const u8) PluginConfig {
+//         var new = self;
+//         new.root_source_file = src;
+//         return new;
+//     }
+
+//     pub fn withFeature(self: PluginConfig, feature: arbor.PluginFeatures) PluginConfig {
+//         var new = self;
+//         new.features |= feature;
+//         return new;
+//     }
+// };
+
 pub const BuildConfig = struct {
-    description: Description,
-    features: arbor.PluginFeatures,
-    root_source_file: []const u8,
+    plugin_config: PluginConfig,
+    plugin_config_path: std.Build.LazyPath,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
-
-    // in-place modification of certain properties
-
-    pub fn withName(self: BuildConfig, name: [:0]const u8) BuildConfig {
-        var new = self;
-        new.description.name = name;
-        return new;
-    }
-
-    pub fn withID(self: BuildConfig, id: [:0]const u8) BuildConfig {
-        var new = self;
-        new.description.id = id;
-        return new;
-    }
-
-    pub fn withSource(self: BuildConfig, src: []const u8) BuildConfig {
-        var new = self;
-        new.root_source_file = src;
-        return new;
-    }
-
-    pub fn withFeature(self: BuildConfig, feature: arbor.PluginFeatures) BuildConfig {
-        var new = self;
-        new.features |= feature;
-        return new;
-    }
 };
 
-pub fn addPlugin(b: *std.Build, config: BuildConfig) !void {
+pub fn addPlugin(b: *std.Build, config: BuildConfig, formats: []const Format) !void {
     const root = b.dependencyFromBuildZig(@This(), .{});
-    const target = config.target;
-    const optimize = config.optimize;
 
-    // NOTE: Explore doing formats as an enum passed in BuildConfig rather than CLI option
-    // Or -- CLI option overrides build options or vice-versa.
-    const format = b.option(Format, "format", "Plugin format");
+    const plugin_config = config.plugin_config;
+    const config_mod = b.addModule("config", .{
+        .root_source_file = config.plugin_config_path,
+    });
+
+    const user_code = b.addLibrary(.{
+        .name = "user_code",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path(config.plugin_config.root_source_file),
+            .target = config.target,
+            .optimize = config.optimize,
+        }),
+    });
 
     const arbor_mod = b.addModule("arbor", .{
         .root_source_file = root.path("src/arbor.zig"),
-        .target = target,
-        .optimize = optimize,
+        .target = config.target,
+        .optimize = config.optimize,
         .link_libc = true,
+        .imports = &.{.{
+            .name = "config",
+            .module = config_mod,
+        }},
     });
 
+    user_code.root_module.addImport("arbor", arbor_mod);
+
     // build UI library
-    buildGUI(b, arbor_mod, target);
+    buildGUI(b, arbor_mod, config.target);
 
     const copy_step = b.step("copy", "Copy plugin to user plugins dir");
-    if (format) |fmt| {
-        const plug = try buildPlugin(b, arbor_mod, fmt, config);
 
-        const bundle_step = try BundleStep.create(b, fmt, config, plug);
+    for (formats) |fmt| {
+        const plug = try buildPlugin(b, fmt, config, plugin_config);
+        const opt = b.addOptions();
+        opt.addOption(Format, "format", fmt);
+        arbor_mod.addOptions("build_options", opt);
+        plug.root_module.addImport("config", config_mod);
+        plug.root_module.addOptions("build_options", opt);
+        plug.root_module.addImport("arbor", arbor_mod);
+        plug.linkLibrary(user_code);
+
+        const bundle_step = try BundleStep.create(
+            b,
+            fmt,
+            plugin_config,
+            config.target.result.os,
+            plug,
+        );
         bundle_step.step.dependOn(&b.addInstallArtifact(plug, .{}).step);
         b.getInstallStep().dependOn(&bundle_step.step);
 
         const copy_cmd = try CopyStep.create(b, fmt, config, bundle_step);
         copy_cmd.step.dependOn(b.getInstallStep());
         copy_step.dependOn(&copy_cmd.step);
-    } else {
-        inline for (formats) |fmt| {
-            const plug = try buildPlugin(b, arbor_mod, fmt, config);
-
-            const bundle_step = try BundleStep.create(b, fmt, config, plug);
-            bundle_step.step.dependOn(&b.addInstallArtifact(plug, .{}).step);
-            b.getInstallStep().dependOn(&bundle_step.step);
-
-            const copy_cmd = try CopyStep.create(b, fmt, config, bundle_step);
-            copy_cmd.step.dependOn(b.getInstallStep());
-            copy_step.dependOn(&copy_cmd.step);
-        }
     }
+    // }
 }
 
 fn buildGUI(
@@ -133,42 +157,34 @@ fn buildGUI(
 
 fn buildPlugin(
     b: *std.Build,
-    module: *std.Build.Module,
-    format: Format,
-    config: BuildConfig,
+    current_format: Format,
+    build_config: BuildConfig,
+    plugin_config: PluginConfig,
 ) !*std.Build.Step.Compile {
     const dep = b.dependencyFromBuildZig(@This(), .{});
-    const build_options = b.addOptions();
-    build_options.addOption(Format, "format", format);
-    build_options.addOption(Description, "plugin_desc", config.description);
-    build_options.addOption(arbor.PluginFeatures, "plugin_features", config.features);
+    const opt = b.addOptions();
+    opt.addOption(Format, "format", current_format);
+
     // make sure we have a file name w/ no spaces
-    const name = b.dupe(config.description.name);
-    std.mem.replaceScalar(u8, name, ' ', '_');
+    const name = b.dupe(plugin_config.description.name);
+    if (std.mem.containsAtLeastScalar(u8, name, 1, ' ')) {
+        @panic("Plugin name cannot contains spaces\n");
+    }
 
-    const usr_plug = b.addStaticLibrary(.{
-        .name = name,
-        .root_source_file = b.path(config.root_source_file),
-        .target = config.target,
-        .optimize = config.optimize,
-        .pic = true,
-    });
-    usr_plug.root_module.addImport("arbor", module);
-
-    const plug_src = switch (format) {
+    const plug_src = switch (current_format) {
         .CLAP => "src/clap_plugin.zig",
         .VST2 => "src/vst2_plugin.zig",
     };
-    const plug = b.addSharedLibrary(.{
+    const plug = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = name,
-        .root_source_file = dep.path(plug_src),
-        .target = config.target,
-        .optimize = config.optimize,
-        .pic = true,
+        .root_module = b.createModule(.{
+            .root_source_file = dep.path(plug_src),
+            .target = build_config.target,
+            .optimize = build_config.optimize,
+            .pic = true,
+        }),
     });
-    plug.linkLibrary(usr_plug);
-    plug.root_module.addOptions("config", build_options);
-    module.addOptions("config", build_options);
 
     return plug;
 }
@@ -177,7 +193,8 @@ pub const BundleStep = struct {
     const Step = std.Build.Step;
     step: Step,
     format: Format,
-    config: BuildConfig,
+    config: PluginConfig,
+    target_os: std.Target.Os,
     build_dep: *Step.Compile,
     bundle_name: ?[]const u8 = null,
     /// path to the generated bundle (which may be just a file)
@@ -186,7 +203,8 @@ pub const BundleStep = struct {
     pub fn create(
         b: *std.Build,
         format: Format,
-        config: BuildConfig,
+        config: PluginConfig,
+        target_os: std.Target.Os,
         build_dep: *Step.Compile,
     ) !*BundleStep {
         const self = try b.allocator.create(BundleStep);
@@ -199,16 +217,17 @@ pub const BundleStep = struct {
             }),
             .format = format,
             .config = config,
+            .target_os = target_os,
             .build_dep = build_dep,
         };
         return self;
     }
 
-    pub fn make(step: *Step, _: std.Progress.Node) !void {
+    pub fn make(step: *Step, _: std.Build.Step.MakeOptions) !void {
         const self: *BundleStep = @fieldParentPtr("step", step);
         const b = self.step.owner;
         const dest = b.install_path;
-        const target_os = self.config.target.result.os.tag;
+        const target_os = self.target_os.tag;
 
         const format_extensions = make: {
             const Array = std.EnumArray(Format, []const u8);
@@ -246,7 +265,9 @@ pub const BundleStep = struct {
                 }), .{});
                 const plist = try bundle_dir.createFile("Info.plist", .{});
                 defer plist.close();
-                try plist.writer().print(osx_bundle_plist, .{
+                // LOVING THE NEW IO INTERFACE 🤣
+                var writer = plist.deprecatedWriter();
+                try writer.print(osx_bundle_plist, .{
                     out_name, //CFBundleExecutable
                     self.config.description.id, //CF BundleIdentifier
                     out_name, //CFBundleName
@@ -303,7 +324,7 @@ pub const CopyStep = struct {
         return self;
     }
 
-    pub fn make(step: *Step, _: std.Progress.Node) !void {
+    pub fn make(step: *Step, _: std.Build.Step.MakeOptions) !void {
         const self: *CopyStep = @fieldParentPtr("step", step);
         const b = step.owner;
         const target = self.config.target;
@@ -367,34 +388,34 @@ const osx_bundle_plist =
     \\<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     \\<plist version="1.0">
     \\<dict>
-    \\	<key>CFBundleDevelopmentRegion</key>
-    \\	<string>English</string>
-    \\	<key>CFBundleExecutable</key>
-    \\	<string>{s}</string>
-    \\	<key>CFBundleGetInfoString</key>
-    \\	<string></string>
-    \\	<key>CFBundleIconFile</key>
-    \\	<string></string>
-    \\	<key>CFBundleIdentifier</key>
-    \\	<string>{s}</string>
-    \\	<key>CFBundleInfoDictionaryVersion</key>
-    \\	<string>6.0</string>
-    \\	<key>CFBundleName</key>
-    \\	<string>{s}</string>
-    \\	<key>CFBundleDisplayName</key>
-    \\	<string>{s}</string>
-    \\	<key>CFBundlePackageType</key>
-    \\	<string>BNDL</string>
-    \\	<key>CFBundleShortVersionString</key>
-    \\	<string>{s}</string>
-    \\	<key>CFBundleSignature</key>
-    \\	<string>????</string>
-    \\	<key>CFBundleVersion</key>
-    \\	<string>{s}</string>
-    \\	<key>CSResourcesFileMapped</key>
-    \\	<true/>
-    \\	<key>NSHumanReadableCopyright</key>
-    \\	<string>{s}</string>
+    \\  <key>CFBundleDevelopmentRegion</key>
+    \\  <string>English</string>
+    \\  <key>CFBundleExecutable</key>
+    \\  <string>{s}</string>
+    \\  <key>CFBundleGetInfoString</key>
+    \\  <string></string>
+    \\  <key>CFBundleIconFile</key>
+    \\  <string></string>
+    \\  <key>CFBundleIdentifier</key>
+    \\  <string>{s}</string>
+    \\  <key>CFBundleInfoDictionaryVersion</key>
+    \\  <string>6.0</string>
+    \\  <key>CFBundleName</key>
+    \\  <string>{s}</string>
+    \\  <key>CFBundleDisplayName</key>
+    \\  <string>{s}</string>
+    \\  <key>CFBundlePackageType</key>
+    \\  <string>BNDL</string>
+    \\  <key>CFBundleShortVersionString</key>
+    \\  <string>{s}</string>
+    \\  <key>CFBundleSignature</key>
+    \\  <string>????</string>
+    \\  <key>CFBundleVersion</key>
+    \\  <string>{s}</string>
+    \\  <key>CSResourcesFileMapped</key>
+    \\  <true/>
+    \\  <key>NSHumanReadableCopyright</key>
+    \\  <string>{s}</string>
     \\  <key>NSHighResolutionCapable</key>
     \\  <true/>
     \\</dict>
@@ -402,87 +423,91 @@ const osx_bundle_plist =
     \\
 ;
 
-pub fn build(b: *std.Build) !void {
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
+pub fn build(_: *std.Build) !void {
+    // const target = b.standardTargetOptions(.{});
+    // const optimize = b.standardOptimizeOption(.{});
 
-    const test_step = b.step("test", "Run library tests");
+    // const test_step = b.step("test", "Run library tests");
 
-    const config = BuildConfig{
-        .description = .{
-            .name = "Test plugin",
-            .id = "com.Arbor.test",
-            .company = "Arboreal Audio",
-            .version = "0.1.0",
-            .copyright = "(c) No One",
-            .url = "",
-            .contact = "",
-            .manual = "",
-            .description = "",
-        },
-        .features = features.STEREO | features.EFFECT | features.GUI,
-        .root_source_file = "",
-        .target = target,
-        .optimize = optimize,
-    };
+    // const config = BuildConfig{
+    //     .description = .{
+    //         .name = "Test plugin",
+    //         .id = "com.Arbor.test",
+    //         .company = "Arboreal Audio",
+    //         .version = "0.1.0",
+    //         .copyright = "(c) No One",
+    //         .url = "",
+    //         .contact = "",
+    //         .manual = "",
+    //         .description = "",
+    //     },
+    //     .features = features.STEREO | features.EFFECT | features.GUI,
+    //     .root_source_file = "",
+    //     .target = target,
+    //     .optimize = optimize,
+    // };
 
-    for (formats) |fmt| {
-        const build_options = b.addOptions();
-        build_options.addOption(Format, "format", fmt);
-        build_options.addOption(arbor.PluginFeatures, "plugin_features", config.features);
-        build_options.addOption(arbor.Plugin.Description, "plugin_desc", config.description);
+    // for (formats) |fmt| {
+    //     const build_options = b.addOptions();
+    //     build_options.addOption(Format, "format", fmt);
+    //     build_options.addOption(arbor.PluginFeatures, "plugin_features", config.features);
+    //     build_options.addOption(arbor.Plugin.Description, "plugin_desc", config.description);
 
-        const mod = b.addModule("arbor", .{
-            .root_source_file = b.path("src/arbor.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
-        mod.addOptions("config", build_options);
+    //     const mod = b.addModule("arbor", .{
+    //         .root_source_file = b.path("src/arbor.zig"),
+    //         .target = target,
+    //         .optimize = optimize,
+    //     });
+    //     mod.addOptions("config", build_options);
 
-        switch (target.result.os.tag) {
-            .linux => {
-                mod.addSystemIncludePath(.{ .cwd_relative = "/usr/include/" });
-                mod.linkSystemLibrary("X11", .{});
-                mod.addCSourceFile(.{
-                    .file = b.path("src/gui/gui_x11.c"),
-                    .flags = &.{"-std=c99"},
-                });
-            },
-            .windows => {
-                mod.linkSystemLibrary("gdi32", .{});
-                mod.linkSystemLibrary("user32", .{});
-                mod.addCSourceFile(.{
-                    .file = b.path("src/gui/gui_w32.c"),
-                    .flags = &.{"-std=c99"},
-                });
-            },
-            .macos => {
-                mod.linkFramework("Cocoa", .{});
-                mod.addCSourceFile(.{
-                    .file = b.path("src/gui/gui_mac.m"),
-                    .flags = &.{"-ObjC"},
-                });
-            },
-            else => @panic("Unimplemented OS\n"),
-        }
-        mod.addCSourceFile(.{
-            .file = b.path("src/gui/olive.c"),
-            .flags = &.{"-DOLIVEC_IMPLEMENTATION"},
-        });
+    //     switch (target.result.os.tag) {
+    //         .linux => {
+    //             mod.addSystemIncludePath(.{ .cwd_relative = "/usr/include/" });
+    //             mod.linkSystemLibrary("X11", .{});
+    //             mod.addCSourceFile(.{
+    //                 .file = b.path("src/gui/gui_x11.c"),
+    //                 .flags = &.{"-std=c99"},
+    //             });
+    //         },
+    //         .windows => {
+    //             mod.linkSystemLibrary("gdi32", .{});
+    //             mod.linkSystemLibrary("user32", .{});
+    //             mod.addCSourceFile(.{
+    //                 .file = b.path("src/gui/gui_w32.c"),
+    //                 .flags = &.{"-std=c99"},
+    //             });
+    //         },
+    //         .macos => {
+    //             mod.linkFramework("Cocoa", .{});
+    //             mod.addCSourceFile(.{
+    //                 .file = b.path("src/gui/gui_mac.m"),
+    //                 .flags = &.{"-ObjC"},
+    //             });
+    //         },
+    //         else => @panic("Unimplemented OS\n"),
+    //     }
+    //     mod.addCSourceFile(.{
+    //         .file = b.path("src/gui/olive.c"),
+    //         .flags = &.{"-DOLIVEC_IMPLEMENTATION"},
+    //     });
 
-        const tests = b.addTest(.{
-            .name = "tests",
-            .root_source_file = b.path("src/tests.zig"),
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-        });
-        tests.root_module.addImport("arbor", mod);
-        tests.root_module.addOptions("config", build_options);
+    //     const tests = b.addTest(.{
+    //         .name = "tests",
+    //         .root_module = b.createModule(.{
+    //             .root_source_file = b.path("src/tests.zig"),
+    //             .target = target,
+    //             .optimize = optimize,
+    //             .link_libc = true,
+    //             .imports = &.{
+    //                 .{ .name = "arbor", .module = mod },
+    //             },
+    //         }),
+    //     });
+    //     tests.root_module.addOptions("config", build_options);
 
-        const run_tests = b.addRunArtifact(tests);
-        test_step.dependOn(&run_tests.step);
-    }
+    //     const run_tests = b.addRunArtifact(tests);
+    //     test_step.dependOn(&run_tests.step);
+    // }
 }
 
 const Dir = std.fs.Dir;

--- a/build.zig
+++ b/build.zig
@@ -71,7 +71,7 @@ pub fn addPlugin(b: *std.Build, config: BuildConfig, formats: []const Format) !v
             .optimize = config.optimize,
         }),
         .use_llvm = true,
-        .use_lld = false,
+        .use_lld = config.target.result.os.tag != .linux,
     });
 
     const arbor_mod = b.addModule("arbor", .{
@@ -188,7 +188,7 @@ fn buildPlugin(
             .strip = false,
         }),
         .use_llvm = true,
-        .use_lld = false,
+        .use_lld = build_config.target.result.os.tag != .linux,
     });
 
     return plug;

--- a/build.zig
+++ b/build.zig
@@ -15,39 +15,6 @@ comptime {
 // TODO: Implement a MacOS Universal Binary build mode which will build both archs & lipo
 // TODO: Configure OSX sysroot so we can supply our own SDK
 
-// pub const PluginConfig = struct {
-//     description: Description,
-//     features: arbor.PluginFeatures,
-//     root_source_file: []const u8,
-//     format: []const Format = all_formats,
-
-//     // in-place modification of certain properties
-
-//     pub fn withName(self: PluginConfig, name: [:0]const u8) PluginConfig {
-//         var new = self;
-//         new.description.name = name;
-//         return new;
-//     }
-
-//     pub fn withID(self: PluginConfig, id: [:0]const u8) PluginConfig {
-//         var new = self;
-//         new.description.id = id;
-//         return new;
-//     }
-
-//     pub fn withSource(self: PluginConfig, src: []const u8) PluginConfig {
-//         var new = self;
-//         new.root_source_file = src;
-//         return new;
-//     }
-
-//     pub fn withFeature(self: PluginConfig, feature: arbor.PluginFeatures) PluginConfig {
-//         var new = self;
-//         new.features |= feature;
-//         return new;
-//     }
-// };
-
 pub const BuildConfig = struct {
     plugin_config: PluginConfig,
     plugin_config_path: std.Build.LazyPath,
@@ -428,92 +395,7 @@ const osx_bundle_plist =
     \\
 ;
 
-pub fn build(_: *std.Build) !void {
-    // const target = b.standardTargetOptions(.{});
-    // const optimize = b.standardOptimizeOption(.{});
-
-    // const test_step = b.step("test", "Run library tests");
-
-    // const config = BuildConfig{
-    //     .description = .{
-    //         .name = "Test plugin",
-    //         .id = "com.Arbor.test",
-    //         .company = "Arboreal Audio",
-    //         .version = "0.1.0",
-    //         .copyright = "(c) No One",
-    //         .url = "",
-    //         .contact = "",
-    //         .manual = "",
-    //         .description = "",
-    //     },
-    //     .features = features.STEREO | features.EFFECT | features.GUI,
-    //     .root_source_file = "",
-    //     .target = target,
-    //     .optimize = optimize,
-    // };
-
-    // for (formats) |fmt| {
-    //     const build_options = b.addOptions();
-    //     build_options.addOption(Format, "format", fmt);
-    //     build_options.addOption(arbor.PluginFeatures, "plugin_features", config.features);
-    //     build_options.addOption(arbor.Plugin.Description, "plugin_desc", config.description);
-
-    //     const mod = b.addModule("arbor", .{
-    //         .root_source_file = b.path("src/arbor.zig"),
-    //         .target = target,
-    //         .optimize = optimize,
-    //     });
-    //     mod.addOptions("config", build_options);
-
-    //     switch (target.result.os.tag) {
-    //         .linux => {
-    //             mod.addSystemIncludePath(.{ .cwd_relative = "/usr/include/" });
-    //             mod.linkSystemLibrary("X11", .{});
-    //             mod.addCSourceFile(.{
-    //                 .file = b.path("src/gui/gui_x11.c"),
-    //                 .flags = &.{"-std=c99"},
-    //             });
-    //         },
-    //         .windows => {
-    //             mod.linkSystemLibrary("gdi32", .{});
-    //             mod.linkSystemLibrary("user32", .{});
-    //             mod.addCSourceFile(.{
-    //                 .file = b.path("src/gui/gui_w32.c"),
-    //                 .flags = &.{"-std=c99"},
-    //             });
-    //         },
-    //         .macos => {
-    //             mod.linkFramework("Cocoa", .{});
-    //             mod.addCSourceFile(.{
-    //                 .file = b.path("src/gui/gui_mac.m"),
-    //                 .flags = &.{"-ObjC"},
-    //             });
-    //         },
-    //         else => @panic("Unimplemented OS\n"),
-    //     }
-    //     mod.addCSourceFile(.{
-    //         .file = b.path("src/gui/olive.c"),
-    //         .flags = &.{"-DOLIVEC_IMPLEMENTATION"},
-    //     });
-
-    //     const tests = b.addTest(.{
-    //         .name = "tests",
-    //         .root_module = b.createModule(.{
-    //             .root_source_file = b.path("src/tests.zig"),
-    //             .target = target,
-    //             .optimize = optimize,
-    //             .link_libc = true,
-    //             .imports = &.{
-    //                 .{ .name = "arbor", .module = mod },
-    //             },
-    //         }),
-    //     });
-    //     tests.root_module.addOptions("config", build_options);
-
-    //     const run_tests = b.addRunArtifact(tests);
-    //     test_step.dependOn(&run_tests.step);
-    // }
-}
+pub fn build(_: *std.Build) void {}
 
 const Dir = std.fs.Dir;
 

--- a/build.zig
+++ b/build.zig
@@ -71,7 +71,7 @@ pub fn addPlugin(b: *std.Build, config: BuildConfig, formats: []const Format) !v
             .optimize = config.optimize,
         }),
         .use_llvm = true,
-        .use_lld = config.target.result.os.tag != .linux,
+        .use_lld = config.target.result.os.tag == .windows,
     });
 
     const arbor_mod = b.addModule("arbor", .{
@@ -188,7 +188,7 @@ fn buildPlugin(
             .strip = false,
         }),
         .use_llvm = true,
-        .use_lld = build_config.target.result.os.tag != .linux,
+        .use_lld = build_config.target.result.os.tag == .windows,
     });
 
     return plug;

--- a/build.zig
+++ b/build.zig
@@ -70,6 +70,8 @@ pub fn addPlugin(b: *std.Build, config: BuildConfig, formats: []const Format) !v
             .target = config.target,
             .optimize = config.optimize,
         }),
+        .use_llvm = true,
+        .use_lld = false,
     });
 
     const arbor_mod = b.addModule("arbor", .{
@@ -183,7 +185,10 @@ fn buildPlugin(
             .target = build_config.target,
             .optimize = build_config.optimize,
             .pic = true,
+            .strip = false,
         }),
+        .use_llvm = true,
+        .use_lld = false,
     });
 
     return plug;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = "arbor",
+    .name = .arbor,
     .version = "0.1.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.15.0",
     .paths = .{
         "src",
         "build.zig",

--- a/examples/Distortion/build.zig
+++ b/examples/Distortion/build.zig
@@ -2,22 +2,13 @@ const std = @import("std");
 const arbor = @import("arbor");
 
 pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
     try arbor.addPlugin(b, .{
-        .description = .{
-            .name = "Example Distortion",
-            .id = "com.Arbor.ExDist",
-            .company = "Arboreal Audio",
-            .version = "0.1.0",
-            .copyright = "(c) 2024 Arboreal Audio, LLC",
-            .url = "",
-            .manual = "",
-            .contact = "",
-            .description = "Vintage analog warmth",
-        },
-        .features = arbor.features.STEREO | arbor.features.EFFECT |
-            arbor.features.GUI,
-        .root_source_file = "plugin.zig",
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
-    });
+        .plugin_config = @import("config.zon"),
+        .plugin_config_path = b.path("config.zon"),
+        .target = target,
+        .optimize = optimize,
+    }, &.{ .CLAP, .VST2 });
 }

--- a/examples/Distortion/build.zig.zon
+++ b/examples/Distortion/build.zig.zon
@@ -1,11 +1,12 @@
 .{
-    .name = "Example Distortion",
+    .name = .Example_Distortion,
     .version = "0.1.0",
     .dependencies = .{
         .arbor = .{
             .path = "../..",
         },
     },
+    .fingerprint = 0x7bad96d95356b2b3,
     .paths = .{
         "",
     },

--- a/examples/Distortion/config.zon
+++ b/examples/Distortion/config.zon
@@ -1,0 +1,19 @@
+.{
+    .description = .{
+        .name = "Example_Distortion",
+        .id = "com.Arbor.ExDist",
+        .company = "Arboreal Audio",
+        .version = "0.1.0",
+        .copyright = "(c) 2024 Arboreal Audio, LLC",
+        .url = "",
+        .manual = "",
+        .contact = "",
+        .description = "Vintage analog warmth",
+    },
+    .features = .{
+        .stereo = true,
+        .effect = true,
+        .distortion = true,
+    },
+    .root_source_file = "plugin.zig",
+}

--- a/examples/Distortion/plugin.zig
+++ b/examples/Distortion/plugin.zig
@@ -19,6 +19,8 @@ const plugin_params = &[_]arbor.Parameter{
 
 export fn init() *arbor.Plugin {
     return arbor.createPlugin(.{
+        .num_inputs = 2,
+        .num_outputs = 2,
         .params = plugin_params,
         .interface = .{
             .deinit = deinit,

--- a/examples/Distortion/plugin.zig
+++ b/examples/Distortion/plugin.zig
@@ -17,15 +17,16 @@ const plugin_params = &[_]arbor.Parameter{
     param.Choice("Mode", Mode.Vintage, .{ .flags = .{} }), // optionally pass a list of names
 };
 
-const allocator = std.heap.c_allocator;
-
 export fn init() *arbor.Plugin {
-    const plugin = arbor.init(allocator, plugin_params, .{
-        .deinit = deinit,
-        .prepare = prepare,
-        .process = process,
+    return arbor.createPlugin(.{
+        .params = plugin_params,
+        .interface = .{
+            .deinit = deinit,
+            .prepare = prepare,
+            .process = process,
+            .createGui = guiInit,
+        },
     });
-    return plugin;
 }
 
 fn deinit(plugin: *arbor.Plugin) void {
@@ -85,39 +86,39 @@ fn process(plugin: *arbor.Plugin, buffer: arbor.AudioBuffer(f32)) void {
 
 fn dbValToText(value: f32, buf: []u8) usize {
     const out = std.fmt.bufPrint(buf, "{d:.2} dB", .{value}) catch |e| {
-        log.err("{!}\n", .{e}, @src());
+        log.err("{}\n", .{e}, @src());
         return 0;
     };
     return out.len;
 }
 
 const draw = arbor.Gui.draw;
+const Color = arbor.Gui.draw.Color;
 
 pub const WIDTH = 500;
 pub const HEIGHT = 600;
-const background_color = draw.Color{ .r = 0, .g = 0x80, .b = 0x80, .a = 0xff };
+const background_color = Color{ .r = 0, .g = 0x80, .b = 0x80, .a = 0xff };
 
-const slider_dark = draw.Color{ .r = 0, .g = 0x70, .b = 0x70, .a = 0xff };
-const silver = draw.Color.fromBits(0xff_aa_aa_aa);
+const slider_dark = Color{ .r = 0, .g = 0x70, .b = 0x70, .a = 0xff };
+const silver = Color.fromBits(0xff_aa_aa_aa);
 
-const highlight_color = draw.Color{ .r = 0x9f, .g = 0xc4, .b = 0x72, .a = 0xff };
-const border_color = draw.Color{ .r = 0x9f, .g = 0xbb, .b = 0x95, .a = 0xff };
+const highlight_color = Color{ .r = 0x9f, .g = 0xc4, .b = 0x72, .a = 0xff };
+const border_color = Color{ .r = 0x9f, .g = 0xbb, .b = 0x95, .a = 0xff };
 
 const TITLE = "DISTORTION";
 
 // Export an entry to our GUI implementation
-export fn gui_init(plugin: *arbor.Plugin) void {
-    const gui = arbor.Gui.init(plugin.allocator, .{
+fn guiInit(plugin: *arbor.Plugin) void {
+    const gui = arbor.Gui.init(plugin, .{
         .layout = .default,
         .width = WIDTH,
         .height = HEIGHT,
         .timer_ms = 16,
         .interface = .{
-            .deinit = gui_deinit,
-            .render = gui_render,
+            .deinit = guiDeinit,
+            .render = guiRender,
         },
     });
-    plugin.gui = gui;
 
     // we can draw the logo here and just copy its memory to the global canvas
     // in our render function
@@ -134,7 +135,7 @@ export fn gui_init(plugin: *arbor.Plugin) void {
     // setup unique properties here
     for (0..plugin.param_info.len) |i| {
         const param_info = plugin.getParamWithId(@intCast(i)) catch |e| {
-            log.err("{!}\n", .{e}, @src());
+            log.err("{}\n", .{e}, @src());
             return;
         };
         if (!std.mem.eql(u8, param_info.name, "Mode")) {
@@ -155,7 +156,7 @@ export fn gui_init(plugin: *arbor.Plugin) void {
                 .label = .{
                     .text = param_info.name,
                     .height = 18,
-                    .color = draw.Color.WHITE,
+                    .color = Color.WHITE,
                     .border = silver,
                     .flags = .{
                         .border = true,
@@ -185,25 +186,25 @@ export fn gui_init(plugin: *arbor.Plugin) void {
                 .label = .{
                     .text = param_info.name,
                     .height = menu_height / 2,
-                    .color = draw.Color.WHITE,
+                    .color = Color.WHITE,
                 },
             });
         }
     }
 }
 
-fn gui_deinit(gui: *arbor.Gui) void {
+fn guiDeinit(gui: *arbor.Gui) void {
     _ = gui;
 }
 
-fn gui_render(gui: *arbor.Gui) void {
+fn guiRender(gui: *arbor.Gui) void {
     // draw our background and frame
-    draw.olivec_fill(gui.canvas, background_color.toBits());
-    draw.olivec_frame(gui.canvas, 2, 2, WIDTH - 4, HEIGHT - 4, 4, border_color.toBits());
+    draw.olivec.olivec_fill(gui.canvas, background_color.toBits());
+    draw.olivec.olivec_frame(gui.canvas, 2, 2, WIDTH - 4, HEIGHT - 4, 4, border_color.toBits());
 
     // draw plugin title
     const title_width = WIDTH / 3;
-    draw.drawText(gui.canvas, .{
+    draw.Text.drawText(gui.canvas, .{
         .text = TITLE,
         .height = 25,
         .color = slider_dark,
@@ -222,7 +223,7 @@ fn gui_render(gui: *arbor.Gui) void {
     }
 
     // render logo
-    draw.olivec_sprite_blend(gui.canvas, 6, 6, 64, 64, logo_canvas);
+    draw.olivec.olivec_sprite_blend(gui.canvas, 6, 6, 64, 64, logo_canvas);
 }
 
 // TODO: Write Zig bindings for Olivec so we can run it at comptime
@@ -237,14 +238,14 @@ var logo_canvas: draw.Canvas = .{
 fn drawLogo() void {
     const cx = 15;
     const cy = 15;
-    draw.olivec_fill(logo_canvas, 0);
-    draw.olivec_circle(logo_canvas, cx, cy, 16, silver.toBits());
-    draw.olivec_line(logo_canvas, cx, 0, cx, 32, slider_dark.toBits());
+    draw.olivec.olivec_fill(logo_canvas, 0);
+    draw.olivec.olivec_circle(logo_canvas, cx, cy, 16, silver.toBits());
+    draw.olivec.olivec_line(logo_canvas, cx, 0, cx, 32, slider_dark.toBits());
     var i: u32 = 3;
     while (i < cy + 2) : (i += 3) {
         const w = i * 2;
         const x = 15 - (w / 2);
-        draw.olivec_line(
+        draw.olivec.olivec_line(
             logo_canvas,
             @intCast(x),
             @intCast(i),

--- a/examples/Filter/build.zig
+++ b/examples/Filter/build.zig
@@ -3,20 +3,9 @@ const arbor = @import("arbor");
 
 pub fn build(b: *std.Build) !void {
     try arbor.addPlugin(b, .{
-        .description = .{
-            .name = "Example Filter",
-            .id = "com.Arbor.ExDist",
-            .company = "Arboreal Audio",
-            .version = "0.1.0",
-            .copyright = "(c) 2024 Arboreal Audio, LLC",
-            .url = "",
-            .manual = "",
-            .contact = "",
-            .description = "Vintage analog warmth",
-        },
-        .features = arbor.features.STEREO | arbor.features.EFFECT,
-        .root_source_file = "plugin.zig",
+        .plugin_config = @import("config.zon"),
+        .plugin_config_path = b.path("config.zon"),
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
-    });
+    }, &.{ .CLAP, .VST2 });
 }

--- a/examples/Filter/build.zig.zon
+++ b/examples/Filter/build.zig.zon
@@ -1,11 +1,12 @@
 .{
-    .name = "Example Filter",
+    .name = .Example_Filter,
     .version = "0.1.0",
     .dependencies = .{
         .arbor = .{
             .path = "../..",
         },
     },
+    .fingerprint = 0x14c38fcb5e845261,
     .paths = .{
         "",
     },

--- a/examples/Filter/config.zon
+++ b/examples/Filter/config.zon
@@ -1,0 +1,20 @@
+.{
+    .description = .{
+        .name = "Example_Filter",
+        .id = "com.Arbor.ExFilt",
+        .company = "Arboreal Audio",
+        .version = "0.1.0",
+        .copyright = "(c) 2024 Arboreal Audio, LLC",
+        .url = "",
+        .manual = "",
+        .contact = "",
+        .description = "Vintage analog warmth",
+    },
+    .features = .{
+        .stereo = true,
+        .effect = true,
+        .eq = true,
+        .gui = false,
+    },
+    .root_source_file = "plugin.zig",
+}

--- a/examples/Filter/plugin.zig
+++ b/examples/Filter/plugin.zig
@@ -4,38 +4,50 @@ const param = arbor.param;
 const log = arbor.log;
 const dsp = arbor.dsp;
 
-const Filter = @This();
+const default_cutoff = 1500;
+const default_q = std.math.sqrt1_2;
 
-const params = &[_]arbor.Parameter{
-    param.Float("Freq", 20, 18e3, 1500, .{ .flags = .{} }),
+const Filter = struct {
+    filter: dsp.Filter,
+    last_cutoff: f32,
+    last_q: f32,
+    params: []const arbor.Parameter = &.{
+        param.Float("Freq", 20, 18e3, default_cutoff, .{}),
+        param.Float("Q", 0.1, 4, default_q, .{}),
+    },
 };
+
+// const params = &[_]arbor.Parameter{
+//     param.Float("Freq", 20, 18e3, 1500, .{ .flags = .{} }),
+// };
 
 const allocator = std.heap.c_allocator;
 
-filter: dsp.Filter,
-last_cutoff: f32,
-
 export fn init() *arbor.Plugin {
     const self = allocator.create(Filter) catch |e| {
-        log.fatal("{!}\n", .{e}, @src());
+        log.fatal("{t}\n", .{e}, @src());
     };
     self.* = .{
         .filter = dsp.Filter.init(
             allocator,
             2,
-            .FirstOrderLowpass,
-            params[0].default_value,
-            std.math.sqrt1_2,
-        ) catch |e| log.fatal("{!}\n", .{e}, @src()),
-        .last_cutoff = params[0].default_value,
+            .Lowpass,
+            default_cutoff,
+            default_q,
+        ) catch |e| log.fatal("{t}\n", .{e}, @src()),
+        .last_cutoff = default_cutoff,
+        .last_q = default_q,
     };
-    const plugin = arbor.init(allocator, params, .{
-        .deinit = deinit,
-        .prepare = prepare,
-        .process = process,
+    return arbor.createPlugin(.{
+        .allocator = allocator,
+        .params = self.params,
+        .interface = .{
+            .deinit = deinit,
+            .prepare = prepare,
+            .process = process,
+        },
+        .user_data = self,
     });
-    plugin.user = self;
-    return plugin;
 }
 
 fn deinit(plugin: *arbor.Plugin) void {
@@ -55,10 +67,16 @@ fn prepare(plugin: *arbor.Plugin, sample_rate: f32, max_frames: u32) void {
 fn process(plugin: *arbor.Plugin, buffer: arbor.AudioBuffer(f32)) void {
     const self = plugin.getUser(Filter);
     const cutoff = plugin.getParamValue(f32, "Freq");
+    const q = plugin.getParamValue(f32, "Q");
     if (self.last_cutoff != cutoff) {
         // TODO: Param smoothing
         self.filter.setCutoff(cutoff, plugin.sample_rate);
         self.last_cutoff = cutoff;
+    }
+
+    if (self.last_q != q) {
+        self.filter.setReso(q, plugin.sample_rate);
+        self.last_q = q;
     }
 
     self.filter.process(buffer.input, buffer.output);

--- a/examples/Filter/plugin.zig
+++ b/examples/Filter/plugin.zig
@@ -22,6 +22,7 @@ const Filter = struct {
 // };
 
 const allocator = std.heap.c_allocator;
+const num_channels = 2;
 
 export fn init() *arbor.Plugin {
     const self = allocator.create(Filter) catch |e| {
@@ -30,7 +31,7 @@ export fn init() *arbor.Plugin {
     self.* = .{
         .filter = dsp.Filter.init(
             allocator,
-            2,
+            num_channels,
             .Lowpass,
             default_cutoff,
             default_q,
@@ -40,6 +41,8 @@ export fn init() *arbor.Plugin {
     };
     return arbor.createPlugin(.{
         .allocator = allocator,
+        .num_inputs = num_channels,
+        .num_outputs = num_channels,
         .params = self.params,
         .interface = .{
             .deinit = deinit,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ ZIG_VERSION="0.15.1"
 
 [ $(uname -m) == 'arm64' ] && ARCH="aarch64" || ARCH=$(uname -m)
 
-TRIPLE="${OS}-${ARCH}-${ZIG_VERSION}"
+TRIPLE="${ARCH}-${OS}-${ZIG_VERSION}"
 
 echo "Getting Zig ${ZIG_VERSION} for ${ARCH} ${OS}"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,9 +4,9 @@ set -e
 
 # ZIG_VERSION="0.15.1"
 
-# [ $(uname -s) == 'Darwin' ] && OS="macos"
-# [ $(uname -s) == 'Linux' ] && OS="linux"
-# [ $OS == 'Windows_NT' ] && OS='windows'
+[ $(uname -s) == 'Darwin' ] && OS="macos"
+[ $(uname -s) == 'Linux' ] && OS="linux"
+[ $OS == 'Windows_NT' ] && OS='windows'
 
 # [ $(uname -m) == 'arm64' ] && ARCH="aarch64" || ARCH=$(uname -m)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,28 +2,28 @@
 
 set -e
 
-ZIG_VERSION="0.15.1"
+# ZIG_VERSION="0.15.1"
 
-[ $(uname -s) == 'Darwin' ] && OS="macos"
-[ $(uname -s) == 'Linux' ] && OS="linux"
-[ $OS == 'Windows_NT' ] && OS='windows'
+# [ $(uname -s) == 'Darwin' ] && OS="macos"
+# [ $(uname -s) == 'Linux' ] && OS="linux"
+# [ $OS == 'Windows_NT' ] && OS='windows'
 
-[ $(uname -m) == 'arm64' ] && ARCH="aarch64" || ARCH=$(uname -m)
+# [ $(uname -m) == 'arm64' ] && ARCH="aarch64" || ARCH=$(uname -m)
 
-TRIPLE="${ARCH}-${OS}-${ZIG_VERSION}"
+# TRIPLE="${ARCH}-${OS}-${ZIG_VERSION}"
 
-echo "Getting Zig ${ZIG_VERSION} for ${ARCH} ${OS}"
+# echo "Getting Zig ${ZIG_VERSION} for ${ARCH} ${OS}"
 
-[ $OS != 'windows' ] && curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-${TRIPLE}.tar.xz" | tar xJ
-if [[ $OS == 'windows' ]]; then
-	choco install zig --version $ZIG_VERSION
-	# powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest https://ziglang.org/builds/zig-${TRIPLE}.zip -OutFile zig-${TRIPLE}.zip"
-	# powershell -Command "Expand-Archive -Path ./zig-${TRIPLE}.zip -DestinationPath ."
-fi
+# [ $OS != 'windows' ] && curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-${TRIPLE}.tar.xz" | tar xJ
+# if [[ $OS == 'windows' ]]; then
+# 	choco install zig --version $ZIG_VERSION
+# 	# powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest https://ziglang.org/builds/zig-${TRIPLE}.zip -OutFile zig-${TRIPLE}.zip"
+# 	# powershell -Command "Expand-Archive -Path ./zig-${TRIPLE}.zip -DestinationPath ."
+# fi
 
-[ $OS != 'windows' ] && ZIG="${PWD}/zig-${TRIPLE}/zig" || ZIG="zig.exe"
+# [ $OS != 'windows' ] && ZIG="${PWD}/zig-${TRIPLE}/zig" || ZIG="zig.exe"
 
-echo "Zig path = ${ZIG}"
+# echo "Zig path = ${ZIG}"
 
 if [[ $OS == 'linux' ]]; then
 	echo "Installing X11 development libraries"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ZIG_VERSION="0.13.0"
+ZIG_VERSION="0.15.1"
 
 [ $(uname -s) == 'Darwin' ] && OS="macos"
 [ $(uname -s) == 'Linux' ] && OS="linux"
@@ -30,10 +30,9 @@ if [[ $OS == 'linux' ]]; then
 	sudo apt install libx11-dev
 fi
 
-echo "Running library tests"
-$ZIG build test
+# echo "Running library tests"
+# $ZIG build test
 
-# Build examples & unit test (all one step)
 EXAMPLES=(Distortion Filter)
 
 for ex in ${EXAMPLES[@]}; do

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,6 @@ EXAMPLES=(Distortion Filter)
 for ex in ${EXAMPLES[@]}; do
 	echo "Building example plugin: $ex"
 	pushd ./examples/$ex
-	$ZIG build
+	zig build
 	popd
 done

--- a/scripts/validate-clap.sh
+++ b/scripts/validate-clap.sh
@@ -15,7 +15,7 @@ else
 	CV=./clap-validator.exe
 fi
 
-EXAMPLES=(Distortion) # Filter example produces a bug in the validator
+EXAMPLES=(Distortion Filter)
 
 for ex in ${EXAMPLES[@]}; do
   $CV validate examples/$ex/zig-out/Example_${ex}.clap

--- a/scripts/validate-vst.sh
+++ b/scripts/validate-vst.sh
@@ -6,12 +6,14 @@ set -e
 [ $(uname -s) == 'Linux' ] && OS='linux'
 [ $OS == 'Windows_NT' ] && OS='windows'
 
+PLUGINVAL_VERSION="v1.0.4"
+
 if [[ $OS == 'windows' ]]; then
-	powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_Windows.zip -OutFile pluginval.zip"
+	powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest https://github.com/Tracktion/pluginval/releases/download/${PLUGINVAL_VERSION}/pluginval_Windows.zip -OutFile pluginval.zip"
 	powershell -Command "Expand-Archive -Path ./pluginval.zip -DestinationPath ."
 	pluginval="./pluginval.exe"
 else
-	wget -O pluginval.zip https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${OS}.zip
+	wget -O pluginval.zip https://github.com/Tracktion/pluginval/releases/download/${PLUGINVAL_VERSION}/pluginval_${OS}.zip
 	unzip pluginval
 	if [[ $(uname -s) == 'Darwin' ]]; then
 		pluginval="pluginval.app/Contents/MacOS/pluginval"

--- a/src/arbor.zig
+++ b/src/arbor.zig
@@ -67,7 +67,7 @@ pub const Plugin = struct {
 
     interface: Interface,
 
-    num_channels: u32 = undefined,
+    num_channels: u32,
     sample_rate: f32 = undefined,
     max_frames: u32 = undefined,
 
@@ -122,18 +122,22 @@ pub const Plugin = struct {
 
 pub const InitOptions = struct {
     allocator: ?Allocator = null,
+    num_inputs: u32,
+    num_outputs: u32,
     params: []const Parameter,
     interface: Plugin.Interface,
     user_data: ?*anyopaque = null,
 };
 
 /// Initialize a Plugin. Caller owns the returned pointer and must free it by
-/// calling "deinit".
+/// calling `deinit`.
 pub fn createPlugin(options: InitOptions) *Plugin {
     const allocator = options.allocator orelse std.heap.c_allocator;
-    const plug = allocator.create(Plugin) catch |e| log.fatal("Plugin create failed: {}\n", .{e}, @src());
+    const plug = allocator.create(Plugin) catch |e|
+        log.fatal("Plugin create failed: {}\n", .{e}, @src());
     plug.* = .{
         .interface = options.interface,
+        .num_channels = @max(options.num_inputs, options.num_outputs),
         .param_info = options.params,
         .params = param.createSlice(allocator, options.params),
         .allocator = allocator,

--- a/src/arbor.zig
+++ b/src/arbor.zig
@@ -43,7 +43,6 @@ pub const clap = @import("clap_api.zig");
 pub const vst2 = @import("vst2_api.zig");
 
 /// User-defined plugin description, converted to format type
-// pub const plugin_desc: DescType = createFormatDescription();
 pub const plugin_desc = config.description;
 pub const plugin_name = plugin_desc.name;
 
@@ -173,31 +172,6 @@ pub fn createFormatDescription() DescType {
         else => @compileError("Unimplemented format"),
     }
 }
-
-// NOTE: Had to convert from an enum to C-style bit flags, since Zig build options
-// generation seems bugged
-/// Bit-packed list of supported plugin features, which will be converted to format-specific feature list
-pub const PluginFeatures_old = u32;
-pub const features = struct {
-    pub const MONO = 1 << 0;
-    pub const STEREO = 1 << 1;
-    pub const SURROUND = 1 << 2;
-    pub const AMBISONIC = 1 << 3;
-    pub const EFFECT = 1 << 4;
-    pub const DISTORTION = 1 << 5;
-    pub const DYNAMICS = 1 << 6;
-    pub const EQ = 1 << 7;
-    pub const REVERB = 1 << 8;
-    pub const PITCH_SHIFT = 1 << 9;
-    pub const MASTERING = 1 << 10;
-    pub const ANALYZER = 1 << 11;
-    pub const RESTORATION = 1 << 12;
-    pub const INSTRUMENT = 1 << 13;
-    pub const SYNTH = 1 << 14;
-    pub const SAMPLER = 1 << 15;
-    pub const DRUM = 1 << 16;
-    pub const GUI = 1 << 17;
-};
 
 const num_features = std.meta.fields(PluginFeatures).len;
 
@@ -404,6 +378,7 @@ pub const log = struct {
         args: anytype,
         comptime src: std.builtin.SourceLocation,
     ) void {
+        if (@import("builtin").mode != .Debug) return;
         std.debug.print(pre ++ fmt, .{ src.file, src.fn_name, src.line } ++ args);
     }
 

--- a/src/arbor.zig
+++ b/src/arbor.zig
@@ -21,18 +21,19 @@
 //! Main source file for framework, collecting everything in one place
 const std = @import("std");
 const assert = std.debug.assert;
-pub const config = @import("config");
+
+const plugin_description = @import("plugin_description.zig");
+const Description = plugin_description.Description;
+const PluginConfig = plugin_description.PluginConfig;
+const PluginFeatures = plugin_description.PluginFeatures;
+const Format = plugin_description.Format;
+pub const config: PluginConfig = @import("config");
+pub const format = @import("build_options").format;
+
 const Allocator = std.mem.Allocator;
 
 pub const param = @import("params.zig");
 pub const Parameter = param.Parameter;
-
-pub const Format = enum {
-    CLAP,
-    VST2,
-    // Big 'ol TODO: VST3,
-};
-const format = config.format;
 
 pub const Gui = @import("gui/Gui.zig");
 
@@ -42,38 +43,16 @@ pub const clap = @import("clap_api.zig");
 pub const vst2 = @import("vst2_api.zig");
 
 /// User-defined plugin description, converted to format type
-pub const plugin_desc: DescType = createFormatDescription();
-pub const plugin_name = config.plugin_desc.name;
+// pub const plugin_desc: DescType = createFormatDescription();
+pub const plugin_desc = config.description;
+pub const plugin_name = plugin_desc.name;
 
 pub const Plugin = struct {
-    pub const Description = struct {
-        /// plugin name
-        name: [:0]const u8,
-        /// unique id for plugin, i.e. com.Company.Plugin
-        id: [:0]const u8,
-        /// company name
-        company: [:0]const u8,
-        /// version string
-        version: [:0]const u8,
-        /// copyright string
-        copyright: [:0]const u8,
-        /// url of your website, not that you need one. It's nice to have!
-        url: [:0]const u8,
-        /// contact url
-        contact: [:0]const u8,
-        /// link to user manual
-        manual: [:0]const u8,
-        /// short description of plugin
-        description: [:0]const u8,
-        // NOTE: Removed features from this struct until bugs w/ Zig build options are fixed
-        // format-agnostic list of plugin features
-        // features: []const PluginFeatures,
-    };
-
     pub const Interface = struct {
         deinit: *const fn (*Plugin) void,
         prepare: *const fn (*Plugin, f32, u32) void,
         process: *const fn (*Plugin, AudioBuffer(f32)) void,
+        createGui: ?*const fn (*Plugin) void = null,
         // TODO: processDouble: *const fn (*Plugin, AudioBuffer(f64)) void,
     };
 
@@ -99,7 +78,7 @@ pub const Plugin = struct {
 
     mutex: std.Thread.Mutex = .{},
 
-    allocator: Allocator = std.heap.c_allocator,
+    allocator: Allocator,
 
     // functions for dealing with a plugin's parameters
 
@@ -108,10 +87,10 @@ pub const Plugin = struct {
             if (std.mem.orderZ(u8, p.name, name).compare(.eq)) {
                 const val = plugin.params[i];
                 switch (@typeInfo(BaseType)) {
-                    .Float => return val,
-                    .Int => return @intFromFloat(val),
-                    .Bool => return @as(BaseType, @as(u1, @intFromFloat(val)) != 0),
-                    .Enum => return @as(
+                    .float => return val,
+                    .int => return @intFromFloat(val),
+                    .bool => return @as(BaseType, @as(u1, @intFromFloat(val)) != 0),
+                    .@"enum" => return @as(
                         BaseType,
                         @enumFromInt(@as(i32, @intFromFloat(val))),
                     ),
@@ -133,6 +112,7 @@ pub const Plugin = struct {
     }
 
     /// Get a pointer to the user's data, if they provided one
+    /// TODO rename this function to be clearer as to its purpose
     pub fn getUser(plugin: *Plugin, comptime UserType: type) *UserType {
         if (plugin.user) |ptr| return cast(*UserType, ptr) else {
             log.fatal("User pointer is null\n", .{}, @src());
@@ -140,32 +120,36 @@ pub const Plugin = struct {
     }
 };
 
-/// Initialize a Plugin. Caller owns the returned pointer and must free it by
-/// calling "deinit".
-pub fn init(
-    allocator: Allocator,
+pub const InitOptions = struct {
+    allocator: ?Allocator = null,
     params: []const Parameter,
     interface: Plugin.Interface,
-) *Plugin {
+    user_data: ?*anyopaque = null,
+};
+
+/// Initialize a Plugin. Caller owns the returned pointer and must free it by
+/// calling "deinit".
+pub fn createPlugin(options: InitOptions) *Plugin {
+    const allocator = options.allocator orelse std.heap.c_allocator;
     const plug = allocator.create(Plugin) catch |e| log.fatal("Plugin create failed: {}\n", .{e}, @src());
     plug.* = .{
-        .interface = interface,
-        .param_info = params,
-        .params = param.createSlice(allocator, params),
+        .interface = options.interface,
+        .param_info = options.params,
+        .params = param.createSlice(allocator, options.params),
         .allocator = allocator,
+        .user = options.user_data,
     };
     return plug;
 }
 
 const DescType = switch (format) {
     .CLAP => clap.PluginDescriptor,
-    .VST2 => Plugin.Description,
+    .VST2 => Description,
 };
 
-/// Create a description that satisfies the requirements of the format being
-/// compiled for.
+/// Create a description that satisfies the requirements of the format being compiled for.
 pub fn createFormatDescription() DescType {
-    const desc = config.plugin_desc;
+    const desc = config.description;
     switch (DescType) {
         clap.PluginDescriptor => {
             return .{
@@ -178,22 +162,10 @@ pub fn createFormatDescription() DescType {
                 .support_url = desc.contact.ptr,
                 .manual_url = desc.manual.ptr,
                 .description = desc.description.ptr,
-                .features = (parseClapFeatures(config.plugin_features) catch |e| {
-                    log.fatal("Parse CLAP features failed: {!}\n", .{e}, @src());
-                }).constSlice().ptr,
+                .features = parseClapFeatures(config.features).ptr,
             };
         },
-        Plugin.Description => return Plugin.Description{
-            .name = desc.name,
-            .id = desc.id,
-            .company = desc.company,
-            .version = desc.version,
-            .url = desc.url,
-            .contact = desc.contact,
-            .manual = desc.manual,
-            .description = desc.description,
-            .copyright = desc.copyright,
-        },
+        Description => return desc,
         else => @compileError("Unimplemented format"),
     }
 }
@@ -201,7 +173,7 @@ pub fn createFormatDescription() DescType {
 // NOTE: Had to convert from an enum to C-style bit flags, since Zig build options
 // generation seems bugged
 /// Bit-packed list of supported plugin features, which will be converted to format-specific feature list
-pub const PluginFeatures = u32;
+pub const PluginFeatures_old = u32;
 pub const features = struct {
     pub const MONO = 1 << 0;
     pub const STEREO = 1 << 1;
@@ -223,49 +195,57 @@ pub const features = struct {
     pub const GUI = 1 << 17;
 };
 
-// TODO: Improve this. Couldn't think of a better way to compare features.
-// There's gotta be a simple data structure which can aid converting between
-// our enum and a format's string representation.
-pub const FeaturesArray = std.BoundedArray(?[*:0]const u8, 18); // < Imagine hard-coding the number of flags
+const num_features = std.meta.fields(PluginFeatures).len;
 
-pub fn parseClapFeatures(comptime feat: PluginFeatures) !FeaturesArray {
+pub fn parseClapFeatures(comptime feat: PluginFeatures) []const ?[*:0]const u8 {
     const F = clap.PluginFeatures;
-    var out = try FeaturesArray.init(0);
+    const Array = struct {
+        var idx: usize = 0;
+        var buf: [num_features]?[*:0]const u8 = undefined;
+        pub fn append(comptime opt: ?[*:0]const u8) void {
+            buf[idx] = opt;
+            idx += 1;
+        }
+        pub fn appendSlice(comptime slice: []const [:0]const u8) void {
+            for (slice) |s| {
+                append(s);
+            }
+        }
+    };
 
-    if (feat & features.INSTRUMENT == 0 and feat & features.EFFECT == 0 and
-        feat & features.ANALYZER == 0)
+    if (!feat.instrument and !feat.effect and !feat.analyzer)
         @compileError("Must have one main CLAP feature: 'instrument', 'audio-effect', 'note-effect', or 'analyzer' ");
 
-    if (feat & features.MONO > 0) try out.append(F.MONO);
-    if (feat & features.STEREO > 0) try out.append(F.STEREO);
-    if (feat & features.SURROUND > 0) try out.append(F.SURROUND);
-    if (feat & features.AMBISONIC > 0) try out.append(F.AMBISONIC);
-    if (feat & features.EFFECT > 0) try out.append(F.AUDIO_EFFECT);
-    if (feat & features.DISTORTION > 0) try out.append(F.DISTORTION);
-    if (feat & features.DYNAMICS > 0) try out.appendSlice(&.{ F.COMPRESSOR, F.GATE, F.EXPANDER });
-    if (feat & features.EQ > 0) try out.append(F.EQUALIZER);
-    if (feat & features.REVERB > 0) try out.append(F.REVERB);
-    if (feat & features.PITCH_SHIFT > 0) try out.append(F.PITCH_SHIFTER);
-    if (feat & features.MASTERING > 0) try out.append(F.MASTERING);
-    if (feat & features.ANALYZER > 0) try out.append(F.ANALYZER);
-    if (feat & features.RESTORATION > 0) try out.append(F.RESTORATION);
-    if (feat & features.INSTRUMENT > 0) try out.append(F.INSTRUMENT);
-    if (feat & features.SYNTH > 0) try out.append(F.SYNTHESIZER);
-    if (feat & features.SAMPLER > 0) try out.append(F.SAMPLER);
-    if (feat & features.DRUM > 0) try out.appendSlice(&.{ F.DRUM, F.DRUM_MACHINE });
+    if (feat.mono) Array.append(F.MONO);
+    if (feat.stereo) Array.append(F.STEREO);
+    if (feat.surround) Array.append(F.SURROUND);
+    if (feat.ambisonic) Array.append(F.AMBISONIC);
+    if (feat.effect) Array.append(F.AUDIO_EFFECT);
+    if (feat.distortion) Array.append(F.DISTORTION);
+    if (feat.dynamics) Array.appendSlice(&.{ F.COMPRESSOR, F.GATE, F.EXPANDER });
+    if (feat.eq) Array.append(F.EQUALIZER);
+    if (feat.reverb) Array.append(F.REVERB);
+    if (feat.pitch_shift) Array.append(F.PITCH_SHIFTER);
+    if (feat.mastering) Array.append(F.MASTERING);
+    if (feat.analyzer) Array.append(F.ANALYZER);
+    if (feat.restoration) Array.append(F.RESTORATION);
+    if (feat.instrument) Array.append(F.INSTRUMENT);
+    if (feat.synth) Array.append(F.SYNTHESIZER);
+    if (feat.sampler) Array.append(F.SAMPLER);
+    if (feat.drum) Array.appendSlice(&.{ F.DRUM, F.DRUM_MACHINE });
 
-    try out.append(null);
+    Array.append(null);
 
-    return out;
+    return &Array.buf;
 }
 
 pub fn parseVst2Features(comptime feat: PluginFeatures) vst2.Category {
-    if (feat & features.EFFECT > 0) return .kPlugCategEffect;
-    if (feat & features.SYNTH > 0) return .kPlugCategSynth;
-    if (feat & features.ANALYZER > 0) return .kPlugCategAnalysis;
-    if (feat & features.MASTERING > 0) return .kPlugCategMastering;
-    if (feat & features.REVERB > 0) return .kPlugCategRoomFx;
-    if (feat & features.RESTORATION > 0) return .kPlugCategRestoration;
+    if (feat.effect) return .kPlugCategEffect;
+    if (feat.synth) return .kPlugCategSynth;
+    if (feat.analyzer) return .kPlugCategAnalysis;
+    if (feat.mastering) return .kPlugCategMastering;
+    if (feat.reverb) return .kPlugCategRoomFx;
+    if (feat.restoration) return .kPlugCategRestoration;
 
     return .kPlugCategUnknown;
 }
@@ -280,7 +260,7 @@ pub const Event = union(enum) {
 
 pub const queue_size = 512;
 pub const Queue = struct {
-    const QueueArray = std.BoundedArray(Event, queue_size);
+    const QueueArray = std.ArrayList(Event);
     events: QueueArray,
     mutex: std.Thread.Mutex = .{},
     allocator: Allocator,
@@ -288,48 +268,49 @@ pub const Queue = struct {
     pub fn init(allocator: Allocator) !*Queue {
         const self = try allocator.create(Queue);
         self.* = .{
-            .events = try QueueArray.init(0),
+            .events = try QueueArray.initCapacity(allocator, queue_size),
             .allocator = allocator,
         };
         return self;
     }
 
     pub fn deinit(self: *Queue) void {
+        self.events.deinit(self.allocator);
         self.allocator.destroy(self);
     }
 
     pub fn push_try(self: *Queue, event: Event) !void {
         if (self.mutex.tryLock()) {
             defer self.mutex.unlock();
-            try self.events.append(event);
+            try self.events.appendBounded(event);
         }
     }
 
     pub fn push_wait(self: *Queue, event: Event) !void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        try self.events.append(event);
+        try self.events.appendBounded(event);
     }
 
     pub fn push_no_lock(self: *Queue, event: Event) !void {
-        try self.events.append(event);
+        try self.events.appendBounded(event);
     }
 
     pub fn next_try(self: *Queue) ?Event {
         if (self.mutex.tryLock()) {
             defer self.mutex.unlock();
-            return self.events.popOrNull();
+            return self.events.pop();
         } else return null;
     }
 
     pub fn next_wait(self: *Queue) ?Event {
         self.mutex.lock();
         defer self.mutex.unlock();
-        return self.events.popOrNull();
+        return self.events.pop();
     }
 
     pub fn next_no_lock(self: *Queue) ?Event {
-        return self.events.popOrNull();
+        return self.events.pop();
     }
 };
 
@@ -452,7 +433,7 @@ pub const log = struct {
 };
 
 pub fn cast(comptime DestType: type, ptr: anytype) DestType {
-    return @alignCast(@ptrCast(ptr));
+    return @ptrCast(@alignCast(ptr));
 }
 
 pub fn Vst2VersionInt(comptime version: []const u8) !i32 {

--- a/src/clap_api.zig
+++ b/src/clap_api.zig
@@ -63,21 +63,21 @@ pub const Id = u32;
 
 pub const PluginEntry = extern struct {
     clap_version: Version,
-    init: *const fn (plugin_path: [*:0]const u8) callconv(.C) bool,
-    deinit: *const fn () callconv(.C) void,
-    get_factory: *const fn (factory_id: [*:0]const u8) callconv(.C) ?*const anyopaque,
+    init: *const fn (plugin_path: [*:0]const u8) callconv(.c) bool,
+    deinit: *const fn () callconv(.c) void,
+    get_factory: *const fn (factory_id: [*:0]const u8) callconv(.c) ?*const anyopaque,
 };
 
 pub const PLUGIN_FACTORY_ID = "clap.plugin-factory";
 
 pub const PluginFactory = extern struct {
-    get_plugin_count: *const fn (factory: ?*const PluginFactory) callconv(.C) u32,
-    get_plugin_descriptor: *const fn (factory: ?*const PluginFactory, index: u32) callconv(.C) ?*const PluginDescriptor,
+    get_plugin_count: *const fn (factory: ?*const PluginFactory) callconv(.c) u32,
+    get_plugin_descriptor: *const fn (factory: ?*const PluginFactory, index: u32) callconv(.c) ?*const PluginDescriptor,
     create_plugin: *const fn (
         factory: ?*const PluginFactory,
         host: ?*const Host,
         plugin_id: [*:0]const u8,
-    ) callconv(.C) ?*const Plugin,
+    ) callconv(.c) ?*const Plugin,
 };
 
 pub const PluginDescriptor = extern struct {
@@ -97,21 +97,21 @@ pub const PluginDescriptor = extern struct {
 pub const Plugin = extern struct {
     desc: ?*const PluginDescriptor,
     plugin_data: ?*anyopaque,
-    init: *const fn (plugin: ?*const Plugin) callconv(.C) bool,
-    destroy: *const fn (plugin: ?*const Plugin) callconv(.C) void,
+    init: *const fn (plugin: ?*const Plugin) callconv(.c) bool,
+    destroy: *const fn (plugin: ?*const Plugin) callconv(.c) void,
     activate: *const fn (
         plugin: ?*Plugin,
         sample_rate: f64,
         min_frames: u32,
         max_frames: u32,
-    ) callconv(.C) bool,
-    deactivate: *const fn (plugin: ?*const Plugin) callconv(.C) void,
-    start_processing: *const fn (plugin: ?*const Plugin) callconv(.C) bool,
-    stop_processing: *const fn (plugin: ?*const Plugin) callconv(.C) void,
-    reset: *const fn (plugin: ?*const Plugin) callconv(.C) void,
-    process: *const fn (plugin: ?*const Plugin, process: ?*const Process) callconv(.C) ProcessStatus,
-    get_extension: *const fn (plugin: ?*const Plugin, id: [*:0]const u8) callconv(.C) ?*const anyopaque,
-    on_main_thread: *const fn (plugin: ?*const Plugin) callconv(.C) void,
+    ) callconv(.c) bool,
+    deactivate: *const fn (plugin: ?*const Plugin) callconv(.c) void,
+    start_processing: *const fn (plugin: ?*const Plugin) callconv(.c) bool,
+    stop_processing: *const fn (plugin: ?*const Plugin) callconv(.c) void,
+    reset: *const fn (plugin: ?*const Plugin) callconv(.c) void,
+    process: *const fn (plugin: ?*const Plugin, process: ?*const Process) callconv(.c) ProcessStatus,
+    get_extension: *const fn (plugin: ?*const Plugin, id: [*:0]const u8) callconv(.c) ?*const anyopaque,
+    on_main_thread: *const fn (plugin: ?*const Plugin) callconv(.c) void,
 };
 
 pub const AudioBuffer = extern struct {
@@ -321,14 +321,14 @@ pub const EventMidi2 = extern struct {
 /// Incoming events, probably from the host
 pub const InputEvents = extern struct {
     ctx: ?*anyopaque,
-    size: *const fn (list: ?*const InputEvents) callconv(.C) u32,
-    get: *const fn (list: ?*const InputEvents, index: u32) callconv(.C) ?*const EventHeader,
+    size: *const fn (list: ?*const InputEvents) callconv(.c) u32,
+    get: *const fn (list: ?*const InputEvents, index: u32) callconv(.c) ?*const EventHeader,
 };
 
 /// Any outgoing events you want to send
 pub const OutputEvents = extern struct {
     ctx: ?*anyopaque,
-    try_push: *const fn (list: ?*const OutputEvents, event: ?*const EventHeader) callconv(.C) bool,
+    try_push: *const fn (list: ?*const OutputEvents, event: ?*const EventHeader) callconv(.c) bool,
 };
 
 pub const Host = extern struct {
@@ -342,10 +342,10 @@ pub const Host = extern struct {
     get_extension: *const fn (
         host: ?*const Host,
         extension_id: [*:0]const u8,
-    ) callconv(.C) ?*const anyopaque,
-    request_restart: *const fn (host: ?*const Host) callconv(.C) void,
-    request_process: *const fn (host: ?*const Host) callconv(.C) void,
-    request_callback: *const fn (host: ?*const Host) callconv(.C) void,
+    ) callconv(.c) ?*const anyopaque,
+    request_restart: *const fn (host: ?*const Host) callconv(.c) void,
+    request_process: *const fn (host: ?*const Host) callconv(.c) void,
+    request_callback: *const fn (host: ?*const Host) callconv(.c) void,
 };
 
 pub const PluginFeatures = struct {
@@ -446,8 +446,8 @@ pub const AudioPorts = extern struct {
         in_place_pair: Id,
     };
 
-    count: *const fn (plugin: ?*const Plugin, is_input: bool) callconv(.C) u32,
-    get: *const fn (plugin: ?*const Plugin, index: u32, is_input: bool, info: ?*Info) callconv(.C) bool,
+    count: *const fn (plugin: ?*const Plugin, is_input: bool) callconv(.c) u32,
+    get: *const fn (plugin: ?*const Plugin, index: u32, is_input: bool, info: ?*Info) callconv(.c) bool,
 };
 
 pub const HostAudioPorts = extern struct {
@@ -473,17 +473,17 @@ pub const HostAudioPorts = extern struct {
         _: u26 = 0,
     };
 
-    is_rescan_flag_supported: *const fn (host: ?*const Host, flag: Flags) callconv(.C) bool,
-    rescan: *const fn (host: ?*const Host, flags: Flags) callconv(.C) void,
+    is_rescan_flag_supported: *const fn (host: ?*const Host, flag: Flags) callconv(.c) bool,
+    rescan: *const fn (host: ?*const Host, flags: Flags) callconv(.c) void,
 };
 
 pub const EXT_LATENCY = "clap.latency";
 pub const Latency = extern struct {
-    get: *const fn (plugin: ?*const Plugin) callconv(.C) u32,
+    get: *const fn (plugin: ?*const Plugin) callconv(.c) u32,
 };
 
 pub const HostLatency = extern struct {
-    changed: *const fn (host: ?*const Host) callconv(.C) void,
+    changed: *const fn (host: ?*const Host) callconv(.c) void,
 };
 
 pub const EXT_LOG = "clap.log";
@@ -498,13 +498,13 @@ pub const HostLog = extern struct {
         PluginMisbehaving,
     };
 
-    log: *const fn (host: ?*const Host, msg: [*:0]const u8) callconv(.C) void,
+    log: *const fn (host: ?*const Host, msg: [*:0]const u8) callconv(.c) void,
 };
 
 pub const EXT_NOTE_NAME = "clap.note-name";
 pub const PluginNoteName = extern struct {
-    count: *const fn (plugin: ?*const Plugin) callconv(.C) u32,
-    get: *const fn (plugin: ?*const Plugin, index: u32, note_name: ?*NoteName) callconv(.C) bool,
+    count: *const fn (plugin: ?*const Plugin) callconv(.c) u32,
+    get: *const fn (plugin: ?*const Plugin, index: u32, note_name: ?*NoteName) callconv(.c) bool,
 
     pub const NoteName = extern struct {
         name: [NAME_SIZE]u8,
@@ -514,7 +514,7 @@ pub const PluginNoteName = extern struct {
     };
 };
 pub const HostNoteName = extern struct {
-    changed: *const fn (host: ?*const Host) callconv(.C) void,
+    changed: *const fn (host: ?*const Host) callconv(.c) void,
 };
 
 pub const EXT_NOTE_PORTS = "clap.note-ports";
@@ -608,23 +608,23 @@ pub const params = struct {
     };
 
     pub const PluginParams = extern struct {
-        count: *const fn (plugin: ?*const Plugin) callconv(.C) u32,
-        get_info: *const fn (plugin: ?*const Plugin, param_index: u32, param_info: ?*Info) callconv(.C) bool,
-        get_value: *const fn (plugin: ?*const Plugin, param_id: Id, out_value: ?*f64) callconv(.C) bool,
+        count: *const fn (plugin: ?*const Plugin) callconv(.c) u32,
+        get_info: *const fn (plugin: ?*const Plugin, param_index: u32, param_info: ?*Info) callconv(.c) bool,
+        get_value: *const fn (plugin: ?*const Plugin, param_id: Id, out_value: ?*f64) callconv(.c) bool,
         value_to_text: *const fn (
             plugin: ?*const Plugin,
             param_id: Id,
             value: f64,
             out_buf: [*:0]u8,
             out_buf_cap: u32,
-        ) callconv(.C) bool,
+        ) callconv(.c) bool,
         text_to_value: *const fn (
             plugin: ?*const Plugin,
             param_id: Id,
             param_value_text: [*:0]const u8,
             out_value: ?*f64,
-        ) callconv(.C) bool,
-        flush: *const fn (plugin: ?*const Plugin, in: ?*const InputEvents, out: ?*const OutputEvents) callconv(.C) void,
+        ) callconv(.c) bool,
+        flush: *const fn (plugin: ?*const Plugin, in: ?*const InputEvents, out: ?*const OutputEvents) callconv(.c) void,
     };
 
     pub const RescanFlags = packed struct(u32) {
@@ -683,9 +683,9 @@ pub const params = struct {
     };
 
     pub const HostParams = extern struct {
-        rescan: *const fn (host: ?*const Host, flags: RescanFlags) callconv(.C) void,
-        clear: *const fn (host: ?*const Host, param_id: Id, flags: ClearFlags) callconv(.C) void,
-        request_flush: *const fn (host: ?*const Host) callconv(.C) void,
+        rescan: *const fn (host: ?*const Host, flags: RescanFlags) callconv(.c) void,
+        clear: *const fn (host: ?*const Host, param_id: Id, flags: ClearFlags) callconv(.c) void,
+        request_flush: *const fn (host: ?*const Host) callconv(.c) void,
     };
 };
 
@@ -719,33 +719,33 @@ pub const gui = struct {
             plugin: ?*const Plugin,
             api: [*:0]const u8,
             is_floating: bool,
-        ) callconv(.C) bool,
+        ) callconv(.c) bool,
         get_preferred_api: *const fn (
             plugin: ?*const Plugin,
             api: ?*[*:0]const u8,
             is_floating: ?*bool,
-        ) callconv(.C) bool,
-        create: *const fn (plugin: ?*const Plugin, api: [*:0]const u8, is_floating: bool) callconv(.C) bool,
-        destroy: *const fn (plugin: ?*const Plugin) callconv(.C) void,
-        set_scale: *const fn (plugin: ?*const Plugin, scale: f64) callconv(.C) bool,
-        get_size: *const fn (plugin: ?*const Plugin, width: ?*u32, height: ?*u32) callconv(.C) bool,
-        can_resize: *const fn (plugin: ?*const Plugin) callconv(.C) bool,
-        get_resize_hints: *const fn (plugin: ?*const Plugin, hints: ?*ResizeHints) callconv(.C) bool,
-        adjust_size: *const fn (plugin: ?*const Plugin, width: ?*u32, height: ?*u32) callconv(.C) bool,
-        set_size: *const fn (plugin: ?*const Plugin, width: u32, height: u32) callconv(.C) bool,
-        set_parent: *const fn (plugin: ?*const Plugin, window: ?*const Window) callconv(.C) bool,
-        set_transient: *const fn (plugin: ?*const Plugin, window: ?*const Window) callconv(.C) bool,
-        suggest_title: *const fn (plugin: ?*const Plugin, title: [*:0]const u8) callconv(.C) void,
-        show: *const fn (plugin: ?*const Plugin) callconv(.C) bool,
-        hide: *const fn (plugin: ?*const Plugin) callconv(.C) bool,
+        ) callconv(.c) bool,
+        create: *const fn (plugin: ?*const Plugin, api: [*:0]const u8, is_floating: bool) callconv(.c) bool,
+        destroy: *const fn (plugin: ?*const Plugin) callconv(.c) void,
+        set_scale: *const fn (plugin: ?*const Plugin, scale: f64) callconv(.c) bool,
+        get_size: *const fn (plugin: ?*const Plugin, width: ?*u32, height: ?*u32) callconv(.c) bool,
+        can_resize: *const fn (plugin: ?*const Plugin) callconv(.c) bool,
+        get_resize_hints: *const fn (plugin: ?*const Plugin, hints: ?*ResizeHints) callconv(.c) bool,
+        adjust_size: *const fn (plugin: ?*const Plugin, width: ?*u32, height: ?*u32) callconv(.c) bool,
+        set_size: *const fn (plugin: ?*const Plugin, width: u32, height: u32) callconv(.c) bool,
+        set_parent: *const fn (plugin: ?*const Plugin, window: ?*const Window) callconv(.c) bool,
+        set_transient: *const fn (plugin: ?*const Plugin, window: ?*const Window) callconv(.c) bool,
+        suggest_title: *const fn (plugin: ?*const Plugin, title: [*:0]const u8) callconv(.c) void,
+        show: *const fn (plugin: ?*const Plugin) callconv(.c) bool,
+        hide: *const fn (plugin: ?*const Plugin) callconv(.c) bool,
     };
 
     pub const HostGui = extern struct {
-        resize_hints_changed: *const fn (host: ?*const Host) callconv(.C) void,
-        request_resize: *const fn (host: ?*const Host, width: u32, height: u32) callconv(.C) bool,
-        request_show: *const fn (host: ?*const Host) callconv(.C) bool,
-        request_hide: *const fn (host: ?*const Host) callconv(.C) bool,
-        closed: *const fn (host: ?*const Host, was_destroyed: bool) callconv(.C) void,
+        resize_hints_changed: *const fn (host: ?*const Host) callconv(.c) void,
+        request_resize: *const fn (host: ?*const Host, width: u32, height: u32) callconv(.c) bool,
+        request_show: *const fn (host: ?*const Host) callconv(.c) bool,
+        request_hide: *const fn (host: ?*const Host) callconv(.c) bool,
+        closed: *const fn (host: ?*const Host, was_destroyed: bool) callconv(.c) void,
     };
 };
 
@@ -763,13 +763,13 @@ pub const posix_fd = struct {
     };
 
     pub const PluginSupport = extern struct {
-        on_fd: *const fn (plugin: ?*const Plugin, fd: i32, flags: Flags) callconv(.C) void,
+        on_fd: *const fn (plugin: ?*const Plugin, fd: i32, flags: Flags) callconv(.c) void,
     };
 
     pub const HostSupport = extern struct {
-        register_fd: *const fn (host: ?*const Host, fd: i32, flags: Flags) callconv(.C) bool,
-        modify_fd: *const fn (host: ?*const Host, fd: i32, flags: Flags) callconv(.C) bool,
-        unregister_fd: *const fn (host: ?*const Host, fd: i32) callconv(.C) bool,
+        register_fd: *const fn (host: ?*const Host, fd: i32, flags: Flags) callconv(.c) bool,
+        modify_fd: *const fn (host: ?*const Host, fd: i32, flags: Flags) callconv(.c) bool,
+        unregister_fd: *const fn (host: ?*const Host, fd: i32) callconv(.c) bool,
     };
 };
 
@@ -777,39 +777,39 @@ pub const EXT_RENDER = "clap.render";
 pub const Render = extern struct {
     const Mode = enum(i32) { Realtime = 0, Offline = 1 };
 
-    has_hard_realtime_requirement: *const fn (plugin: ?*const Plugin) callconv(.C) bool,
-    set: *const fn (plugin: ?*const Plugin, mode: Mode) callconv(.C) bool,
+    has_hard_realtime_requirement: *const fn (plugin: ?*const Plugin) callconv(.c) bool,
+    set: *const fn (plugin: ?*const Plugin, mode: Mode) callconv(.c) bool,
 };
 
 pub const InStream = extern struct {
     ctx: ?*anyopaque,
 
-    read: *const fn (stream: ?*const InStream, buffer: ?*anyopaque, size: u64) callconv(.C) i64,
+    read: *const fn (stream: ?*const InStream, buffer: ?*anyopaque, size: u64) callconv(.c) i64,
 };
 
 pub const OutStream = extern struct {
     ctx: ?*anyopaque,
 
-    write: *const fn (stream: ?*const OutStream, buffer: ?*const anyopaque, size: u64) callconv(.C) i64,
+    write: *const fn (stream: ?*const OutStream, buffer: ?*const anyopaque, size: u64) callconv(.c) i64,
 };
 
 pub const EXT_STATE = "clap.state";
 pub const PluginState = extern struct {
-    save: *const fn (plugin: ?*const Plugin, stream: ?*const OutStream) callconv(.C) bool,
-    load: *const fn (plugin: ?*const Plugin, stream: ?*const InStream) callconv(.C) bool,
+    save: *const fn (plugin: ?*const Plugin, stream: ?*const OutStream) callconv(.c) bool,
+    load: *const fn (plugin: ?*const Plugin, stream: ?*const InStream) callconv(.c) bool,
 };
 
 pub const HostState = extern struct {
-    mark_dirty: *const fn (host: ?*const Host) callconv(.C) void,
+    mark_dirty: *const fn (host: ?*const Host) callconv(.c) void,
 };
 
 pub const EXT_TAIL = "clap.tail";
 pub const PluginTail = extern struct {
-    get: *const fn (plugin: ?*const Plugin) callconv(.C) u32,
+    get: *const fn (plugin: ?*const Plugin) callconv(.c) u32,
 };
 
 pub const HostTail = extern struct {
-    changed: *const fn (host: ?*const Host) callconv(.C) void,
+    changed: *const fn (host: ?*const Host) callconv(.c) void,
 };
 
 pub const EXT_THREAD_CHECK = "clap.thread-check";
@@ -817,14 +817,14 @@ pub const EXT_THREAD_CHECK = "clap.thread-check";
 /// sure that the functions are called on the correct threads.
 /// It is highly recommended that hosts implement this extension.
 pub const HostThreadCheck = extern struct {
-    is_main_thread: *const fn (host: ?*const Host) callconv(.C) bool,
-    is_audio_thread: *const fn (host: ?*const Host) callconv(.C) bool,
+    is_main_thread: *const fn (host: ?*const Host) callconv(.c) bool,
+    is_audio_thread: *const fn (host: ?*const Host) callconv(.c) bool,
 };
 
 pub const EXT_TIMER_SUPPORT = "clap.timer-support";
 pub const PluginTimer = extern struct {
     /// [main-thread]
-    on_timer: *const fn (plugin: ?*const Plugin, timer_id: Id) callconv(.C) void,
+    on_timer: *const fn (plugin: ?*const Plugin, timer_id: Id) callconv(.c) void,
 };
 
 pub const HostTimer = extern struct {
@@ -833,10 +833,10 @@ pub const HostTimer = extern struct {
     /// 30 Hz should be allowed.
     /// Returns true on success.
     /// [main-thread]
-    register_timer: *const fn (host: ?*const Host, period_ms: u32, timer_id: ?*Id) callconv(.C) bool,
+    register_timer: *const fn (host: ?*const Host, period_ms: u32, timer_id: ?*Id) callconv(.c) bool,
     /// Returns true on success.
     /// [main-thread]
-    unregister_timer: *const fn (host: ?*const Host, timer_id: Id) callconv(.C) bool,
+    unregister_timer: *const fn (host: ?*const Host, timer_id: Id) callconv(.c) bool,
 };
 
 pub const Color = extern struct {

--- a/src/clap_plugin.zig
+++ b/src/clap_plugin.zig
@@ -232,6 +232,8 @@ const Params = struct {
             const param = plug.param_info[id];
             @memset(display[0..size], 0); // clear display string
             if (param.flags.stepped) {
+                // NOTE: Stepped values may be negative. We need different logic for an enum vs a
+                // regular stepped param
                 const ival: u32 = @intFromFloat(@round(value));
                 if (param.flags.is_enum) {
                     if (param.enum_choices) |choices| {
@@ -245,7 +247,7 @@ const Params = struct {
                     };
                 }
             } else {
-                _ = std.fmt.bufPrintZ(display[0..size], "{d:.2}", .{value}) catch |e| {
+                _ = std.fmt.bufPrintZ(display[0..size], "{d:.4}", .{value}) catch |e| {
                     log.err("{}\n", .{e}, @src());
                     return false;
                 };
@@ -261,10 +263,28 @@ const Params = struct {
         value_text: [*:0]const u8,
         out_value: ?*f64,
     ) callconv(.c) bool {
-        _ = out_value;
-        _ = value_text;
-        _ = param_id;
-        _ = plugin;
+        if (plug_cast(plugin).plugin) |plug| {
+            if (param_id >= plug.param_info.len)
+                return false;
+            const param_info = plug.param_info[param_id];
+            const text: []const u8 = std.mem.span(value_text);
+            const val: *f64 = out_value orelse return false;
+            if (param_info.flags.is_enum) {
+                if (param_info.enum_choices) |choices| {
+                    for (choices, 0..) |choice, i| {
+                        if (std.mem.eql(u8, choice, text)) {
+                            val.* = @floatFromInt(i);
+                            return true;
+                        }
+                    }
+                }
+            }
+            val.* = std.fmt.parseFloat(f64, text) catch |e| {
+                log.err("{}\n", .{e}, @src());
+                return false;
+            };
+            return true;
+        }
         return false;
     }
 

--- a/src/clap_plugin.zig
+++ b/src/clap_plugin.zig
@@ -595,7 +595,9 @@ pub fn processInEvent(plugin: *ClapPlugin, event: ?*const clap.EventHeader) void
             switch (e.type) {
                 .PARAM_VALUE => {
                     const param_event = cast(*const clap.EventParamValue, e);
-                    plug.params[param_event.param_id] = @floatCast(param_event.value);
+                    const in_val: f32 = @floatCast(param_event.value);
+                    const param_info = plug.param_info[param_event.param_id];
+                    plug.params[param_event.param_id] = std.math.clamp(in_val, param_info.min_value, param_info.max_value);
                     if (plug.gui) |gui| {
                         gui.in_events.push_try(.{ .param_change = .{
                             .id = param_event.param_id,

--- a/src/clap_plugin.zig
+++ b/src/clap_plugin.zig
@@ -4,7 +4,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const arbor = @import("arbor.zig");
-const config = @import("config");
+const config = arbor.config;
 const log = arbor.log;
 const cast = arbor.cast;
 const Slice = arbor.Slice;
@@ -23,6 +23,10 @@ fn plug_cast(ptr: ?*const clap.Plugin) *ClapPlugin {
 
 const ClapPlugin = @This();
 
+// Need this static global bc API wants a pointer, where our backend returns a new struct by value
+// each time. Copy the result of `arbor.createFormatDescription()` to this var.
+var descriptor: clap.PluginDescriptor = undefined;
+
 /// user plugin
 plugin: ?*arbor.Plugin = null,
 
@@ -38,7 +42,7 @@ host_params: ?*const clap.params.HostParams = null,
 host_fd_support: ?*const clap.posix_fd.HostSupport = null,
 
 const AudioPorts = struct {
-    fn count(plugin: ?*const clap.Plugin, is_input: bool) callconv(.C) u32 {
+    fn count(plugin: ?*const clap.Plugin, is_input: bool) callconv(.c) u32 {
         _ = is_input;
         _ = plugin;
         return 1;
@@ -49,7 +53,7 @@ const AudioPorts = struct {
         index: u32,
         is_input: bool,
         info: ?*clap.AudioPorts.Info,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         _ = is_input;
         if (index > 1)
             return false;
@@ -76,7 +80,7 @@ const AudioPorts = struct {
 
 // TODO: Implement plugin note ports
 // const NotePorts = struct {
-//     fn count(plugin: ?*const clap.Plugin, is_input: bool) callconv(.C) u32 {
+//     fn count(plugin: ?*const clap.Plugin, is_input: bool) callconv(.c) u32 {
 //         _ = is_input;
 //         _ = plugin;
 //         // TODO: Query whether there are note ports
@@ -88,15 +92,15 @@ const AudioPorts = struct {
 //         index: u32,
 //         is_input: bool,
 //         info: ?*clap.clap_note_port_info_t,
-//     ) callconv(.C) bool {
+//     ) callconv(.c) bool {
 //         _ = is_input;
 //         _ = plugin;
 //         if (index > 0)
 //             return false;
 //         info.*.id = 0;
 //         std.log.defaultLog(.info, .default, "Note port: {s}", .{info.*.name});
-//         info.*.supported_dialects = clap.CLAP_NOTE_DIALECT_MIDI;
-//         info.*.preferred_dialect = clap.CLAP_NOTE_DIALECT_CLAP;
+//         info.*.supported_dialects = clap.cLAP_NOTE_DIALECT_MIDI;
+//         info.*.preferred_dialect = clap.cLAP_NOTE_DIALECT_CLAP;
 //         return true;
 //     }
 
@@ -107,7 +111,7 @@ const AudioPorts = struct {
 // };
 
 pub const Latency = struct {
-    fn getLatency(plugin: ?*const clap.Plugin) callconv(.C) u32 {
+    fn getLatency(plugin: ?*const clap.Plugin) callconv(.c) u32 {
         if (plug_cast(plugin).plugin) |plug| {
             if (@hasField(@TypeOf(plug.*), "latency"))
                 return plug.latency
@@ -125,7 +129,7 @@ const State = struct {
     pub fn save(
         plugin: ?*const clap.Plugin,
         stream: ?*const clap.OutStream,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             const num_params = plug.params.len;
             // PROBLEM: This crashes the plugin!
@@ -142,7 +146,7 @@ const State = struct {
     pub fn load(
         plugin: ?*const clap.Plugin,
         stream: ?*const clap.InStream,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             const num_params = plug.params.len;
             if (stream) |str|
@@ -162,14 +166,14 @@ const State = struct {
 };
 
 const Params = struct {
-    pub fn count(plugin: ?*const clap.Plugin) callconv(.C) u32 {
+    pub fn count(plugin: ?*const clap.Plugin) callconv(.c) u32 {
         if (plug_cast(plugin).plugin) |plug|
             return @intCast(plug.params.len)
         else
             return 0;
     }
 
-    fn getInfo(plugin: ?*const clap.Plugin, index: u32, info: ?*clap.params.Info) callconv(.C) bool {
+    fn getInfo(plugin: ?*const clap.Plugin, index: u32, info: ?*clap.params.Info) callconv(.c) bool {
         const plug = plug_cast(plugin).plugin orelse {
             log.err("Plugin is null\n", .{}, @src());
             return false;
@@ -201,7 +205,7 @@ const Params = struct {
         return false;
     }
 
-    pub fn getValue(plugin: ?*const clap.Plugin, id: clap.Id, value: ?*f64) callconv(.C) bool {
+    pub fn getValue(plugin: ?*const clap.Plugin, id: clap.Id, value: ?*f64) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             if (id >= plug.params.len) return false;
             const val = if (plug.param_info[id].flags.stepped)
@@ -222,7 +226,7 @@ const Params = struct {
         value: f64,
         display: [*:0]u8,
         size: u32,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             if (id >= plug.params.len) return false;
             const param = plug.param_info[id];
@@ -256,7 +260,7 @@ const Params = struct {
         param_id: clap.Id,
         value_text: [*:0]const u8,
         out_value: ?*f64,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         _ = out_value;
         _ = value_text;
         _ = param_id;
@@ -264,7 +268,7 @@ const Params = struct {
         return false;
     }
 
-    fn flush(plugin: ?*const clap.Plugin, in: ?*const clap.InputEvents, out: ?*const clap.OutputEvents) callconv(.C) void {
+    fn flush(plugin: ?*const clap.Plugin, in: ?*const clap.InputEvents, out: ?*const clap.OutputEvents) callconv(.c) void {
         // TODO: Handle output events
         _ = out;
         const plug = plug_cast(plugin);
@@ -299,7 +303,7 @@ const Gui = struct {
         plugin: ?*const clap.Plugin,
         api: [*:0]const u8,
         is_floating: bool,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         _ = plugin;
         return std.mem.orderZ(u8, api, GUI_API).compare(.eq) and !is_floating;
     }
@@ -308,7 +312,7 @@ const Gui = struct {
         plugin: ?*const clap.Plugin,
         api: ?*[*:0]const u8,
         is_floating: ?*bool,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         _ = plugin;
         if (api) |ptr| ptr.* = GUI_API;
         if (is_floating) |ptr| ptr.* = false;
@@ -319,12 +323,13 @@ const Gui = struct {
         plugin: ?*const clap.Plugin,
         api: [*:0]const u8,
         is_floating: bool,
-    ) callconv(.C) bool {
+    ) callconv(.c) bool {
         if (!isAPISupported(plugin, api, is_floating))
             return false;
         if (plug_cast(plugin).plugin) |plug| {
             std.debug.assert(plug.gui == null);
-            arbor.Gui.gui_init(plug);
+            if (plug.interface.createGui) |func|
+                func(plug);
             if (plug.gui) |gui| {
                 const clap_plug = plug_cast(plugin);
                 if (builtin.os.tag == .linux) {
@@ -338,7 +343,7 @@ const Gui = struct {
         return false;
     }
 
-    fn destroyGui(plugin: ?*const clap.Plugin) callconv(.C) void {
+    fn destroyGui(plugin: ?*const clap.Plugin) callconv(.c) void {
         const clap_plug = plug_cast(plugin);
         if (clap_plug.plugin) |plug| {
             std.debug.assert(plug.gui != null);
@@ -352,13 +357,13 @@ const Gui = struct {
         }
     }
 
-    fn setScale(plugin: ?*const clap.Plugin, scale: f64) callconv(.C) bool {
+    fn setScale(plugin: ?*const clap.Plugin, scale: f64) callconv(.c) bool {
         _ = scale;
         _ = plugin;
         return false;
     }
 
-    fn getSize(plugin: ?*const clap.Plugin, width: ?*u32, height: ?*u32) callconv(.C) bool {
+    fn getSize(plugin: ?*const clap.Plugin, width: ?*u32, height: ?*u32) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             if (plug.gui) |gui| {
                 const size = gui.getSize();
@@ -369,30 +374,30 @@ const Gui = struct {
         return true;
     }
 
-    fn canResize(plugin: ?*const clap.Plugin) callconv(.C) bool {
+    fn canResize(plugin: ?*const clap.Plugin) callconv(.c) bool {
         _ = plugin;
         return false;
     }
 
-    fn getResizeHints(plugin: ?*const clap.Plugin, hints: ?*clap.gui.ResizeHints) callconv(.C) bool {
+    fn getResizeHints(plugin: ?*const clap.Plugin, hints: ?*clap.gui.ResizeHints) callconv(.c) bool {
         _ = hints;
         _ = plugin;
         return false;
     }
 
-    fn adjustSize(plugin: ?*const clap.Plugin, width: ?*u32, height: ?*u32) callconv(.C) bool {
+    fn adjustSize(plugin: ?*const clap.Plugin, width: ?*u32, height: ?*u32) callconv(.c) bool {
         return getSize(plugin, width, height);
     }
 
     // TODO: Handle this
-    fn setSize(plugin: ?*const clap.Plugin, width: u32, height: u32) callconv(.C) bool {
+    fn setSize(plugin: ?*const clap.Plugin, width: u32, height: u32) callconv(.c) bool {
         _ = height;
         _ = width;
         _ = plugin;
         return true;
     }
 
-    fn setParent(plugin: ?*const clap.Plugin, clap_window: ?*const clap.gui.Window) callconv(.C) bool {
+    fn setParent(plugin: ?*const clap.Plugin, clap_window: ?*const clap.gui.Window) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             const window = clap_window orelse {
                 log.err("Window is null\n", .{}, @src());
@@ -416,18 +421,18 @@ const Gui = struct {
         return false;
     }
 
-    fn setTransient(plugin: ?*const clap.Plugin, clap_window: ?*const clap.gui.Window) callconv(.C) bool {
+    fn setTransient(plugin: ?*const clap.Plugin, clap_window: ?*const clap.gui.Window) callconv(.c) bool {
         _ = clap_window;
         _ = plugin;
         return false;
     }
 
-    fn suggestTitle(plugin: ?*const clap.Plugin, title: [*:0]const u8) callconv(.C) void {
+    fn suggestTitle(plugin: ?*const clap.Plugin, title: [*:0]const u8) callconv(.c) void {
         _ = title;
         _ = plugin;
     }
 
-    fn show(plugin: ?*const clap.Plugin) callconv(.C) bool {
+    fn show(plugin: ?*const clap.Plugin) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             if (plug.gui) |gui| GuiPlatform.guiSetVisible(gui.impl, true);
             return true;
@@ -435,7 +440,7 @@ const Gui = struct {
         return false;
     }
 
-    fn hide(plugin: ?*const clap.Plugin) callconv(.C) bool {
+    fn hide(plugin: ?*const clap.Plugin) callconv(.c) bool {
         if (plug_cast(plugin).plugin) |plug| {
             if (plug.gui) |gui| GuiPlatform.guiSetVisible(gui.impl, false);
             return true;
@@ -467,7 +472,7 @@ pub const PosixFDSupport = struct {
         plugin: ?*const clap.Plugin,
         fd: i32,
         flags: clap.posix_fd.Flags,
-    ) callconv(.C) void {
+    ) callconv(.c) void {
         _ = fd;
         _ = flags;
         if (plug_cast(plugin).plugin) |plug| {
@@ -480,7 +485,7 @@ pub const PosixFDSupport = struct {
     };
 };
 
-pub fn init(plugin: ?*const clap.Plugin) callconv(.C) bool {
+pub fn init(plugin: ?*const clap.Plugin) callconv(.c) bool {
     const clap_plug = plug_cast(plugin);
 
     // create user plugin
@@ -523,7 +528,7 @@ pub fn init(plugin: ?*const clap.Plugin) callconv(.C) bool {
     return true;
 }
 
-pub fn destroy(plugin: ?*const clap.Plugin) callconv(.C) void {
+pub fn destroy(plugin: ?*const clap.Plugin) callconv(.c) void {
     const clap_plug = plug_cast(plugin);
     if (clap_plug.plugin) |plug| {
         plug.interface.deinit(plug);
@@ -537,7 +542,7 @@ pub fn activate(
     sample_rate: f64,
     min_frames_count: u32,
     max_frames_count: u32,
-) callconv(.C) bool {
+) callconv(.c) bool {
     if (plug_cast(plugin).plugin) |plug| {
         plug.interface.prepare(plug, @floatCast(sample_rate), max_frames_count);
         _ = min_frames_count;
@@ -545,16 +550,16 @@ pub fn activate(
     } else return false;
 }
 
-pub fn deactivate(plugin: ?*const clap.Plugin) callconv(.C) void {
+pub fn deactivate(plugin: ?*const clap.Plugin) callconv(.c) void {
     _ = plugin;
 }
-pub fn startProcessing(plugin: ?*const clap.Plugin) callconv(.C) bool {
+pub fn startProcessing(plugin: ?*const clap.Plugin) callconv(.c) bool {
     if (plugin) |_| return true else return false;
 }
-pub fn stopProcessing(plugin: ?*const clap.Plugin) callconv(.C) void {
+pub fn stopProcessing(plugin: ?*const clap.Plugin) callconv(.c) void {
     _ = plugin;
 }
-pub fn reset(plugin: ?*const clap.Plugin) callconv(.C) void {
+pub fn reset(plugin: ?*const clap.Plugin) callconv(.c) void {
     _ = plugin;
 }
 
@@ -577,7 +582,7 @@ pub fn processInEvent(plugin: *ClapPlugin, event: ?*const clap.EventHeader) void
                             .value = plug.param_info[param_event.param_id]
                                 .getNormalizedValue(@floatCast(param_event.value)),
                         } }) catch |err| {
-                            log.err("in_events push failed: {!}\n", .{err}, @src());
+                            log.err("in_events push failed: {}\n", .{err}, @src());
                             return;
                         };
                         gui.wants_repaint.store(true, .release);
@@ -634,7 +639,7 @@ pub fn processOutEvent(plugin: *ClapPlugin, clap_events: *const clap.OutputEvent
 pub fn process(
     plugin: ?*const clap.Plugin,
     process_info: ?*const clap.Process,
-) callconv(.C) clap.ProcessStatus {
+) callconv(.c) clap.ProcessStatus {
     var clap_plug = plug_cast(plugin);
     const plug = clap_plug.plugin orelse {
         log.err("User plugin is null\n", .{}, @src());
@@ -719,7 +724,7 @@ fn slicePtr(in: [*][*]f32, num_ch: usize, offset: usize, end: usize) [*]Slice(f3
     }
 }
 
-pub fn getExtension(plugin: ?*const clap.Plugin, id: [*:0]const u8) callconv(.C) ?*const anyopaque {
+pub fn getExtension(plugin: ?*const clap.Plugin, id: [*:0]const u8) callconv(.c) ?*const anyopaque {
     _ = plugin;
     if (std.mem.orderZ(u8, id, clap.EXT_LATENCY).compare(.eq))
         return &Latency.Data;
@@ -732,7 +737,7 @@ pub fn getExtension(plugin: ?*const clap.Plugin, id: [*:0]const u8) callconv(.C)
         return &State.Data;
     if (std.mem.orderZ(u8, id, clap.EXT_PARAMS).compare(.eq))
         return &Params.Data;
-    if (config.plugin_features & arbor.features.GUI > 0)
+    if (config.features.gui)
         if (std.mem.orderZ(u8, id, clap.EXT_GUI).compare(.eq))
             return &Gui.Data;
     if (std.mem.orderZ(u8, id, clap.EXT_POSIX_FD_SUPPORT).compare(.eq))
@@ -740,13 +745,13 @@ pub fn getExtension(plugin: ?*const clap.Plugin, id: [*:0]const u8) callconv(.C)
     return null;
 }
 
-pub fn onMainThread(plugin: ?*const clap.Plugin) callconv(.C) void {
+pub fn onMainThread(plugin: ?*const clap.Plugin) callconv(.c) void {
     _ = plugin;
 }
 
 // Factory
 const Factory = struct {
-    fn getPluginCount(factory: ?*const clap.PluginFactory) callconv(.C) u32 {
+    fn getPluginCount(factory: ?*const clap.PluginFactory) callconv(.c) u32 {
         _ = factory;
         return 1;
     }
@@ -754,16 +759,17 @@ const Factory = struct {
     fn getPluginDescriptor(
         factory: ?*const clap.PluginFactory,
         index: u32,
-    ) callconv(.C) ?*const clap.PluginDescriptor {
+    ) callconv(.c) ?*const clap.PluginDescriptor {
+        descriptor = arbor.createFormatDescription();
         _ = factory;
-        return if (index == 0) &arbor.plugin_desc else null;
+        return if (index == 0) &descriptor else null;
     }
 
     fn createPlugin(
         factory: ?*const clap.PluginFactory,
         host: ?*const clap.Host,
         plugin_id: [*:0]const u8,
-    ) callconv(.C) ?*const clap.Plugin {
+    ) callconv(.c) ?*const clap.Plugin {
         _ = factory;
         const h = host orelse {
             log.err("Host is null\n", .{}, @src());
@@ -779,7 +785,7 @@ const Factory = struct {
             };
             clap_plug.* = .{
                 .clap_plugin = .{
-                    .desc = &arbor.plugin_desc,
+                    .desc = &descriptor,
                     .plugin_data = clap_plug,
                     .init = init,
                     .destroy = destroy,
@@ -807,15 +813,15 @@ const Factory = struct {
 
 // Entry
 const Entry = struct {
-    fn init(plugin_path: [*:0]const u8) callconv(.C) bool {
+    fn init(plugin_path: [*:0]const u8) callconv(.c) bool {
         _ = plugin_path;
 
         return true;
     }
 
-    fn deinit() callconv(.C) void {}
+    fn deinit() callconv(.c) void {}
 
-    fn get_factory(factory_id: [*:0]const u8) callconv(.C) ?*const anyopaque {
+    fn get_factory(factory_id: [*:0]const u8) callconv(.c) ?*const anyopaque {
         if (std.mem.orderZ(u8, factory_id, clap.PLUGIN_FACTORY_ID).compare(.eq)) {
             return &Factory.Data;
         } else return null;

--- a/src/gui/Gui.zig
+++ b/src/gui/Gui.zig
@@ -23,9 +23,6 @@ const AtomicBool = std.atomic.Value(bool);
 
 const Gui = @This();
 
-/// User gui init
-pub extern fn gui_init(*Plugin) void;
-
 pub const GuiConfig = struct {
     layout: LayoutType,
     width: u32,
@@ -64,23 +61,23 @@ wants_repaint: AtomicBool = AtomicBool.init(true),
 var arena_impl = std.heap.ArenaAllocator.init(std.heap.c_allocator);
 const arena = arena_impl.allocator();
 
-/// Call this from within your gui_init function to init the GUI backend
-pub fn init(allocator: Allocator, config: GuiConfig) *Gui {
-    _ = allocator;
-    const ptr = arena.create(Gui) catch |e| log.fatal("{!}\n", .{e}, @src());
+/// Call this from within your gui init function to init the GUI backend
+pub fn init(plugin: *Plugin, config: GuiConfig) *Gui {
+    const ptr = arena.create(Gui) catch |e| log.fatal("{}\n", .{e}, @src());
     const bits = arena.alloc(u32, config.width * config.height) catch |e|
-        log.fatal("{!}\n", .{e}, @src());
+        log.fatal("{}\n", .{e}, @src());
     ptr.* = .{
         .allocator = arena,
         .bits = bits,
         .impl = Platform.guiCreate(ptr, bits.ptr, config.width, config.height, config.timer_ms, arbor.plugin_name),
         .interface = config.interface,
         .layout = config.layout,
-        .components = std.ArrayList(Component).init(arena),
-        .in_events = Queue.init(arena) catch |e| log.fatal("{!}\n", .{e}, @src()),
-        .out_events = Queue.init(arena) catch |e| log.fatal("{!}\n", .{e}, @src()),
-        .canvas = draw.olivec_canvas(bits.ptr, config.width, config.height, config.width),
+        .components = .empty,
+        .in_events = Queue.init(arena) catch |e| log.fatal("{}\n", .{e}, @src()),
+        .out_events = Queue.init(arena) catch |e| log.fatal("{}\n", .{e}, @src()),
+        .canvas = draw.olivec.olivec_canvas(bits.ptr, config.width, config.height, config.width),
     };
+    plugin.gui = ptr;
 
     return ptr;
 }
@@ -100,7 +97,7 @@ pub fn requestDraw(self: *Gui) void {
     self.wants_repaint.store(true, .release);
 }
 
-fn render(self: *Gui) callconv(.C) void {
+fn render(self: *Gui) callconv(.c) void {
     // unload event queue
     self.processInEvents();
 
@@ -108,7 +105,7 @@ fn render(self: *Gui) callconv(.C) void {
 
     if (builtin.mode == .Debug) {
         if (debug_mouse_pos) {
-            draw.olivec_circle(
+            draw.olivec.olivec_circle(
                 self.canvas,
                 @intFromFloat(self.state.mouse_pos.x),
                 @intFromFloat(self.state.mouse_pos.y),
@@ -117,7 +114,7 @@ fn render(self: *Gui) callconv(.C) void {
             );
         }
         if (debug_grid) {
-            draw.olivec_line(
+            draw.olivec.olivec_line(
                 self.canvas,
                 @divTrunc(self.getSize().x, 2),
                 0,
@@ -125,7 +122,7 @@ fn render(self: *Gui) callconv(.C) void {
                 self.getSize().y,
                 debug_grid_color.toBits(),
             );
-            draw.olivec_line(
+            draw.olivec.olivec_line(
                 self.canvas,
                 0,
                 @divTrunc(self.getSize().y, 2),
@@ -142,7 +139,7 @@ fn render(self: *Gui) callconv(.C) void {
             self.out_events.push_wait(.{
                 .param_change = .{ .id = i, .value = c.value },
             }) catch |e| {
-                log.err("out_events push failed: {!}\n", .{e}, @src());
+                log.err("out_events push failed: {}\n", .{e}, @src());
                 return;
             };
             c.param_changed = false;
@@ -164,13 +161,13 @@ fn processInEvents(self: *Gui) void {
     }
 }
 
-fn sysInputEvent(self: *Gui, cursor_x: i32, cursor_y: i32, state: GuiState) callconv(.C) void {
+fn sysInputEvent(self: *Gui, cursor_x: i32, cursor_y: i32, state: GuiState) callconv(.c) void {
     if (self.state.type != state)
         self.state.type = state;
     self.processGesture(
         .{ .x = cursor_x, .y = cursor_y },
     ) catch |e| {
-        log.err("{!}\n", .{e}, @src());
+        log.err("{}\n", .{e}, @src());
         return;
     };
     self.requestDraw();
@@ -183,8 +180,8 @@ pub fn getSize(self: Gui) Vec2 {
 // NOTE: We do expect pointers for now, would prefer not to rely on heap
 // allocation but our "inheritance" model kind of forces that.
 pub fn addComponent(self: *Gui, component: Component) void {
-    self.components.append(component) catch |e|
-        log.err("Component append failed: {!}\n", .{e}, @src());
+    self.components.append(self.allocator, component) catch |e|
+        log.err("Component append failed: {}\n", .{e}, @src());
 }
 
 pub fn getComponent(self: *Gui, id: usize) *Component {
@@ -396,7 +393,7 @@ pub const Slider = struct {
 
     pub fn init(allocator: Allocator, param: *const arbor.Parameter, color: Color) *Slider {
         const self = allocator.create(Slider) catch |e|
-            log.fatal("Slider alloc failed: {!}\n", .{e}, @src());
+            log.fatal("Slider alloc failed: {}\n", .{e}, @src());
         self.* = .{ .param = param, .color = color, .flags = .{} };
         return self;
     }
@@ -412,7 +409,7 @@ pub const Slider = struct {
         const top = self.bounds.y + (height - val_height);
 
         // draw borders
-        draw.olivec_rect(
+        draw.olivec.olivec_rect(
             canvas,
             @intCast(self.bounds.x),
             @intCast(self.bounds.y),
@@ -421,7 +418,7 @@ pub const Slider = struct {
             self.background_color.toBits(),
         );
 
-        draw.olivec_rect(
+        draw.olivec.olivec_rect(
             canvas,
             @intCast(self.bounds.x),
             @intCast(top),
@@ -433,7 +430,7 @@ pub const Slider = struct {
         if (self.label) |l| {
             const text_y: u32 = self.bounds.y + height;
             const text_x: u32 = self.bounds.x;
-            draw.drawText(canvas, l, .{
+            draw.Text.drawText(canvas, l, .{
                 .x = text_x,
                 .y = text_y,
                 .width = self.bounds.width,
@@ -446,7 +443,7 @@ pub const Slider = struct {
             if (slider.param.value_to_text) |func| {
                 const denorm = slider.param.valueFromNormalized(self.value);
                 const len = func(denorm, &buf);
-                draw.drawText(canvas, .{
+                draw.Text.drawText(canvas, .{
                     .text = buf[0..len],
                     .height = 15,
                     .color = Color.WHITE,
@@ -497,7 +494,7 @@ pub const Menu = struct {
         border_thickness: u32,
         highlight_color: Color,
     ) *Menu {
-        const self = allocator.create(Menu) catch |e| log.fatal("Menu init failed: {!}\n", .{e}, @src());
+        const self = allocator.create(Menu) catch |e| log.fatal("Menu init failed: {}\n", .{e}, @src());
         self.* = .{
             .choices = choices,
             .border_color = border_color,
@@ -517,7 +514,7 @@ pub const Menu = struct {
         const label_height = self.bounds.height / 2;
 
         if (menu.open and menu.is_mouse_over) {
-            draw.olivec_rect(
+            draw.olivec.olivec_rect(
                 canvas,
                 @intCast(self.bounds.x),
                 @intCast(self.bounds.y),
@@ -529,7 +526,7 @@ pub const Menu = struct {
             for (menu.choices, 0..) |choice, i| {
                 if (menu.mouse_choice) |mc| {
                     if (i == mc) {
-                        draw.olivec_rect(
+                        draw.olivec.olivec_rect(
                             canvas,
                             @intCast(self.bounds.x),
                             @intCast(self.bounds.y + (choice_h * @as(u32, @intCast(i)))),
@@ -539,7 +536,7 @@ pub const Menu = struct {
                         );
                     }
                 }
-                draw.drawText(canvas, .{
+                draw.Text.drawText(canvas, .{
                     .text = choice,
                     .height = choice_h,
                     .color = Color.WHITE,
@@ -554,7 +551,7 @@ pub const Menu = struct {
         }
 
         if (self.label) |label| {
-            draw.drawText(canvas, label, .{
+            draw.Text.drawText(canvas, label, .{
                 .x = self.bounds.x,
                 .y = self.bounds.y,
                 .width = self.bounds.width,
@@ -564,7 +561,7 @@ pub const Menu = struct {
 
         const menu_y = self.bounds.y + label_height;
 
-        draw.olivec_rect(
+        draw.olivec.olivec_rect(
             canvas,
             @intCast(self.bounds.x),
             @intCast(menu_y),
@@ -572,7 +569,7 @@ pub const Menu = struct {
             @intCast(label_height),
             self.background_color.toBits(),
         );
-        draw.olivec_frame(
+        draw.olivec.olivec_frame(
             canvas,
             @intCast(self.bounds.x),
             @intCast(menu_y),
@@ -586,7 +583,7 @@ pub const Menu = struct {
             @intFromFloat(self.value *
                 (@as(f32, @floatFromInt(menu.choices.len)) - 1))
         ];
-        draw.drawText(canvas, .{
+        draw.Text.drawText(canvas, .{
             .text = current,
             .height = label_height / 2,
             .color = Color.WHITE,
@@ -705,7 +702,7 @@ const debug_grid = false;
 const debug_grid_color = Color{ .r = 0xff, .g = 0, .b = 0, .a = 0xff };
 
 comptime {
-    @export(render, .{ .name = "gui_render", .linkage = .weak });
-    @export(sysInputEvent, .{ .name = "sysInputEvent", .linkage = .weak });
-    @export(Platform.guiTimerCallback, .{ .name = "guiTimerCallback", .linkage = .weak });
+    @export(&render, .{ .name = "gui_render", .linkage = .weak });
+    @export(&sysInputEvent, .{ .name = "sysInputEvent", .linkage = .weak });
+    @export(&Platform.guiTimerCallback, .{ .name = "guiTimerCallback", .linkage = .weak });
 }

--- a/src/gui/Text.zig
+++ b/src/gui/Text.zig
@@ -42,7 +42,7 @@ pub fn drawText(
         rect.y;
 
     if (label.flags.background) {
-        draw.olivec_rect(
+        draw.olivec.olivec_rect(
             canvas,
             @intCast(rect.x),
             @intCast(rect.y),
@@ -52,7 +52,7 @@ pub fn drawText(
         );
     }
     if (label.flags.border) {
-        draw.olivec_frame(
+        draw.olivec.olivec_frame(
             canvas,
             @intCast(rect.x),
             @intCast(rect.y),

--- a/src/gui/draw.zig
+++ b/src/gui/draw.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 pub const olivec = @import("olivec.zig");
-pub usingnamespace olivec;
+pub const Canvas = olivec.Canvas;
 pub const Text = @import("Text.zig");
-pub usingnamespace Text;
 pub const Color = @import("Color.zig");
-pub usingnamespace Color;
 
 pub const Vec2 = extern struct {
     x: f32,

--- a/src/gui/platform.zig
+++ b/src/gui/platform.zig
@@ -68,7 +68,7 @@ pub extern fn guiSetParent(gui: *GuiImpl, window: Window) void;
 pub extern fn guiSetVisible(gui: *GuiImpl, visible: bool) void;
 pub extern fn guiRender(gui: *GuiImpl, internal: bool) void;
 
-pub fn guiTimerCallback(timer: NSTimerRef, gui: *Gui) callconv(.C) void {
+pub fn guiTimerCallback(timer: NSTimerRef, gui: *Gui) callconv(.c) void {
     _ = timer;
     if (gui.wants_repaint.load(.acquire)) {
         guiRender(gui.impl, true);

--- a/src/params.zig
+++ b/src/params.zig
@@ -44,7 +44,7 @@ pub const Parameter = struct {
 
 pub const Options = struct {
     /// set of flags used for configuring parameter
-    flags: Parameter.Flags,
+    flags: Parameter.Flags = .{},
     /// function to convert text into parameter value
     text_to_value: ?*const fn (text: []const u8) f32 = null,
     /// function to convert parameter value into text
@@ -98,9 +98,9 @@ pub fn Choice(
 ) Parameter {
     const T = @TypeOf(default);
     const info = @typeInfo(T);
-    if (info != .Enum) @compileError("Expected an enum instance");
+    if (info != .@"enum") @compileError("Expected an enum instance");
 
-    const fields = info.Enum.fields;
+    const fields = info.@"enum".fields;
     const choices = options.enum_choices orelse std.meta.fieldNames(T);
 
     var f = options.flags;

--- a/src/plugin_description.zig
+++ b/src/plugin_description.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+
+pub const PluginConfig = struct {
+    description: Description,
+    features: PluginFeatures,
+    root_source_file: []const u8,
+
+    // in-place modification of certain properties
+
+    pub fn withName(self: PluginConfig, name: [:0]const u8) PluginConfig {
+        var new = self;
+        new.description.name = name;
+        return new;
+    }
+
+    pub fn withID(self: PluginConfig, id: [:0]const u8) PluginConfig {
+        var new = self;
+        new.description.id = id;
+        return new;
+    }
+
+    pub fn withSource(self: PluginConfig, src: []const u8) PluginConfig {
+        var new = self;
+        new.root_source_file = src;
+        return new;
+    }
+};
+
+pub const Description = struct {
+    /// plugin name
+    name: [:0]const u8,
+    /// unique id for plugin, i.e. com.Company.Plugin
+    id: [:0]const u8,
+    /// company name
+    company: [:0]const u8,
+    /// version string
+    version: [:0]const u8,
+    /// copyright string
+    copyright: [:0]const u8,
+    /// url of your website, not that you need one. It's nice to have!
+    url: [:0]const u8,
+    /// contact url
+    contact: [:0]const u8,
+    /// link to user manual
+    manual: [:0]const u8,
+    /// short description of plugin
+    description: [:0]const u8,
+    // NOTE: Removed features from this struct until bugs w/ Zig build options are fixed
+    // format-agnostic list of plugin features
+    // features: []const PluginFeatures,
+};
+
+pub const PluginFeatures = packed struct(u32) {
+    mono: bool = false,
+    stereo: bool = true,
+    surround: bool = false,
+    ambisonic: bool = false,
+    effect: bool = true,
+    distortion: bool = false,
+    dynamics: bool = false,
+    eq: bool = false,
+    reverb: bool = false,
+    pitch_shift: bool = false,
+    mastering: bool = false,
+    analyzer: bool = false,
+    restoration: bool = false,
+    instrument: bool = false,
+    synth: bool = false,
+    sampler: bool = false,
+    drum: bool = false,
+    gui: bool = true,
+    _: u14 = 0,
+
+    pub fn toInt(self: PluginFeatures) u32 {
+        return @bitCast(self);
+    }
+};
+
+pub const Format = enum {
+    CLAP,
+    VST2,
+    // Big 'ol TODO: VST3,
+};

--- a/src/vst2_api.zig
+++ b/src/vst2_api.zig
@@ -123,7 +123,7 @@ pub const HostCallback = ?*const fn (
     value: isize,
     ptr: ?*anyopaque,
     opt: f32,
-) callconv(.C) isize;
+) callconv(.c) isize;
 
 /// Host->plugin communication
 /// See `Opcodes` for possible options
@@ -134,30 +134,30 @@ pub const Dispatch = ?*const fn (
     value: isize,
     ptr: ?*anyopaque,
     opt: f32,
-) callconv(.C) isize;
+) callconv(.c) isize;
 
 pub const Process = ?*const fn (
     effect: ?*AEffect,
     inputs: [*][*]f32,
     outputs: [*][*]f32,
     frames: i32,
-) callconv(.C) void;
+) callconv(.c) void;
 pub const ProcessDouble = ?*const fn (
     effect: ?*AEffect,
     inputs: [*][*]f64,
     outputs: [*][*]f64,
     frames: i32,
-) callconv(.C) void;
+) callconv(.c) void;
 
 pub const SetParameter = ?*const fn (
     effect: ?*AEffect,
     index: i32,
     parameter: f32,
-) callconv(.C) void;
+) callconv(.c) void;
 pub const GetParameter = ?*const fn (
     effect: ?*AEffect,
     index: i32,
-) callconv(.C) f32;
+) callconv(.c) f32;
 
 /// Host-to-plugin instructions
 pub const Opcode = enum(i32) {

--- a/src/vst2_plugin.zig
+++ b/src/vst2_plugin.zig
@@ -7,7 +7,7 @@ const log = arbor.log;
 const cast = arbor.cast;
 const builtin = @import("builtin");
 
-const config = @import("config");
+const config = arbor.config;
 
 const vst2 = @import("vst2_api.zig");
 
@@ -32,7 +32,7 @@ host_callback: *const fn (
     value: isize,
     ptr: ?*anyopaque,
     opt: f32,
-) callconv(.C) isize,
+) callconv(.c) isize,
 plugin: *Plugin, // our specific plugin data
 
 in_events: *arbor.Queue,
@@ -54,7 +54,7 @@ fn dispatch(
     value: isize,
     ptr: ?*anyopaque,
     opt: f32,
-) callconv(.C) isize {
+) callconv(.c) isize {
     var plugin: *VstPlugin = plugCast(effect);
     const plug = plugin.plugin;
     const code = std.meta.intToEnum(vst2.Opcode, opcode) catch return -1;
@@ -92,7 +92,7 @@ fn dispatch(
         .GetVendorString => {
             if (ptr) |p| {
                 var buf: [*]u8 = @ptrCast(p);
-                const vendor = arbor.plugin_desc.company;
+                const vendor = arbor.config.description.company;
                 @memset(buf[0..vst2.StringConstants.MaxVendorStrLen], 0);
                 @memcpy(buf[0..vendor.len], vendor);
                 return 0;
@@ -100,7 +100,7 @@ fn dispatch(
         },
         .GetVendorVersion => {
             return arbor.Vst2VersionInt(arbor.plugin_desc.version) catch |e| {
-                log.err("{s}: {!}\n", .{ @tagName(code), e }, @src());
+                log.err("{s}: {}\n", .{ @tagName(code), e }, @src());
                 return 1;
             };
         },
@@ -114,13 +114,13 @@ fn dispatch(
             }
         },
         .GetPlugCategory => {
-            return @intFromEnum(arbor.parseVst2Features(config.plugin_features));
+            return @intFromEnum(arbor.parseVst2Features(config.features));
         },
         .GetParamName => {
             if (index >= 0 and index < plug.param_info.len) {
                 if (ptr) |p| {
                     const name = plug.getParamName(@intCast(index)) catch |e| {
-                        log.err("{s}: {!}\n", .{ @tagName(code), e }, @src());
+                        log.err("{s}: {}\n", .{ @tagName(code), e }, @src());
                         return 1;
                     };
                     var buf: [*]u8 = @ptrCast(p);
@@ -161,7 +161,7 @@ fn dispatch(
                     } else { // no value-to-text fn, just format it
                         var buf: [max_len]u8 = .{0} ** max_len;
                         const print = std.fmt.bufPrintZ(&buf, "{d:.2}", .{val}) catch |e| {
-                            log.err("{s}: {!}\n", .{ @tagName(code), e }, @src());
+                            log.err("{s}: {}\n", .{ @tagName(code), e }, @src());
                             return 1;
                         };
                         @memcpy(out[0..print.len], print);
@@ -176,7 +176,7 @@ fn dispatch(
                 const id: usize = @intCast(index);
                 const text: []const u8 = std.mem.span(@as([*:0]u8, @ptrCast(ptr)));
                 const val: f32 = std.fmt.parseFloat(f32, text) catch |e| {
-                    log.err("{!}\n", .{e}, @src());
+                    log.err("{}\n", .{e}, @src());
                     return 1;
                 };
                 plug.params[id] = val;
@@ -197,7 +197,7 @@ fn dispatch(
             return 0;
         },
         .EditGetRect => {
-            if (config.plugin_features & arbor.features.GUI == 0) return 0;
+            if (!config.features.gui) return 0;
             // copy to ptr
             if (ptr) |p| {
                 const dest = arbor.cast(**vst2.Rect, p);
@@ -220,11 +220,12 @@ fn dispatch(
             return 0;
         },
         .EditOpen => {
-            if (config.plugin_features & arbor.features.GUI == 0) return 0;
+            if (!config.features.gui) return 0;
             // Init GUI
             // ptr = native parent window (HWND, NSView/NSWindow?, X Window)
             assert(plug.gui == null);
-            Gui.gui_init(plug);
+            if (plug.interface.createGui) |func|
+                func(plug);
             const gui = plug.gui orelse {
                 log.err("{s}: Gui is null\n", .{@tagName(code)}, @src());
                 return 0;
@@ -263,7 +264,7 @@ fn dispatch(
             return 1;
         },
         .EditClose => {
-            if (config.plugin_features & arbor.features.GUI == 0) return 0;
+            if (!config.features.gui) return 0;
             // Close GUI
             if (plug.gui) |gui| {
                 gui.deinit();
@@ -309,7 +310,7 @@ fn dispatch(
         .GetInputProperties => {
             // TODO: Use `index` to support multiple pins
             const pin = allocator.create(vst2.PinProperties) catch |e| {
-                log.err("{!}\n", .{e}, @src());
+                log.err("{}\n", .{e}, @src());
                 return 1;
             };
             pin.* = std.mem.zeroes(vst2.PinProperties);
@@ -319,7 +320,7 @@ fn dispatch(
             @memcpy(pin.shortLabel[0..name.len], name);
 
             if (ptr) |p| {
-                var dest: *vst2.PinProperties = @alignCast(@ptrCast(p));
+                var dest: *vst2.PinProperties = @ptrCast(@alignCast(p));
                 dest = pin;
                 return 0;
             }
@@ -328,7 +329,7 @@ fn dispatch(
         .GetOutputProperties => {
             // TODO: Use `index` to support multiple pins
             const pin = allocator.create(vst2.PinProperties) catch |e| {
-                log.err("{!}\n", .{e}, @src());
+                log.err("{}\n", .{e}, @src());
                 return 1;
             };
             pin.* = std.mem.zeroes(vst2.PinProperties);
@@ -338,7 +339,7 @@ fn dispatch(
             @memcpy(pin.shortLabel[0..name.len], name);
 
             if (ptr) |p| {
-                var dest: *vst2.PinProperties = @alignCast(@ptrCast(p));
+                var dest: *vst2.PinProperties = @ptrCast(@alignCast(p));
                 dest = pin;
                 return 0;
             }
@@ -368,7 +369,7 @@ fn processInEvents(vst: *VstPlugin) void {
 
                 if (plug.gui) |gui| {
                     gui.in_events.push_try(event) catch |e| {
-                        log.err("{!}\n", .{e}, @src());
+                        log.err("{}\n", .{e}, @src());
                     };
                     gui.requestDraw();
                 }
@@ -408,7 +409,7 @@ fn processReplacing(
     inputs: [*][*]f32,
     outputs: [*][*]f32,
     frames: i32,
-) callconv(.C) void {
+) callconv(.c) void {
     audio_thread = std.Thread.getCurrentId();
     const vst = plugCast(effect);
     const plugin = vst.plugin;
@@ -437,14 +438,14 @@ fn processDoubleReplacing(
     inputs: [*][*]f64,
     outputs: [*][*]f64,
     frames: i32,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = effect;
     _ = frames;
     _ = outputs;
     _ = inputs;
 }
 
-fn setParameter(effect: ?*vst2.AEffect, index: i32, value: f32) callconv(.C) void {
+fn setParameter(effect: ?*vst2.AEffect, index: i32, value: f32) callconv(.c) void {
     main_thread = std.Thread.getCurrentId();
     const vst = plugCast(effect);
     const plugin = vst.plugin;
@@ -463,7 +464,7 @@ fn setParameter(effect: ?*vst2.AEffect, index: i32, value: f32) callconv(.C) voi
     }
 }
 
-fn getParameter(effect: ?*vst2.AEffect, index: i32) callconv(.C) f32 {
+fn getParameter(effect: ?*vst2.AEffect, index: i32) callconv(.c) f32 {
     const plugin = plugCast(effect).plugin;
     if (index >= 0 and index < plugin.param_info.len) {
         const id: usize = @intCast(index);
@@ -497,12 +498,12 @@ pub fn init(alloc: std.mem.Allocator, host_callback: vst2.HostCallback) !*vst2.A
         .flags = .{
             .HasStateChunk = true,
             .HasReplacing = true,
-            .HasEditor = (config.plugin_features & arbor.features.GUI > 0),
+            .HasEditor = (config.features.gui),
         },
         .latency = 0,
         .uniqueID = std.mem.bytesToValue(i32, arbor.plugin_desc.id),
         .version = arbor.Vst2VersionInt(arbor.plugin_desc.version) catch |e| {
-            log.fatal("{!}\n", .{e}, @src());
+            log.fatal("{}\n", .{e}, @src());
             return error.ParseVersionFailed;
         },
         .object = self,
@@ -519,6 +520,6 @@ pub fn deinit(self: *VstPlugin, alloc: std.mem.Allocator) void {
     alloc.destroy(self);
 }
 
-export fn VSTPluginMain(callback: vst2.HostCallback) callconv(.C) ?*anyopaque {
+export fn VSTPluginMain(callback: vst2.HostCallback) callconv(.c) ?*anyopaque {
     return init(allocator, callback) catch return null;
 }

--- a/src/vst2_plugin.zig
+++ b/src/vst2_plugin.zig
@@ -16,8 +16,6 @@ const Parameter = arbor.Parameter;
 const Gui = arbor.Gui;
 const PlatformGui = Gui.Platform;
 
-const allocator = std.heap.c_allocator;
-
 const VstPlugin = @This();
 
 var audio_thread: std.Thread.Id = undefined;
@@ -55,7 +53,7 @@ fn dispatch(
     ptr: ?*anyopaque,
     opt: f32,
 ) callconv(.c) isize {
-    var plugin: *VstPlugin = plugCast(effect);
+    const plugin: *VstPlugin = plugCast(effect);
     const plug = plugin.plugin;
     const code = std.meta.intToEnum(vst2.Opcode, opcode) catch return -1;
     switch (code) {
@@ -86,7 +84,7 @@ fn dispatch(
         },
         // ISSUE: This is kinda bunk right? Since the outer AEffect will end up destroying itself?
         .Close => {
-            plugin.deinit(allocator);
+            plugin.deinit(plug.allocator);
             return 0;
         },
         .GetVendorString => {
@@ -309,7 +307,7 @@ fn dispatch(
         .ProcessEvents => {},
         .GetInputProperties => {
             // TODO: Use `index` to support multiple pins
-            const pin = allocator.create(vst2.PinProperties) catch |e| {
+            const pin = plug.allocator.create(vst2.PinProperties) catch |e| {
                 log.err("{}\n", .{e}, @src());
                 return 1;
             };
@@ -328,7 +326,7 @@ fn dispatch(
         },
         .GetOutputProperties => {
             // TODO: Use `index` to support multiple pins
-            const pin = allocator.create(vst2.PinProperties) catch |e| {
+            const pin = plug.allocator.create(vst2.PinProperties) catch |e| {
                 log.err("{}\n", .{e}, @src());
                 return 1;
             };
@@ -473,18 +471,19 @@ fn getParameter(effect: ?*vst2.AEffect, index: i32) callconv(.c) f32 {
     return 0;
 }
 
-pub fn init(alloc: std.mem.Allocator, host_callback: vst2.HostCallback) !*vst2.AEffect {
+pub fn init(host_callback: vst2.HostCallback) !*vst2.AEffect {
+    const plugin = Plugin.init();
+    const alloc = plugin.allocator;
     const self = try alloc.create(VstPlugin);
     self.* = .{
         .effect = try alloc.create(vst2.AEffect),
-        .plugin = Plugin.init(),
+        .plugin = plugin,
         .in_events = try arbor.Queue.init(alloc),
         .host_callback = host_callback orelse {
             log.err("host_callback is null\n", .{}, @src());
             return error.InitFailed;
         },
     };
-    self.plugin.num_channels = 2; // TODO: DOn't hardcode
     self.effect.* = .{
         .dispatcher = dispatch,
         .processReplacing = processReplacing,
@@ -493,8 +492,8 @@ pub fn init(alloc: std.mem.Allocator, host_callback: vst2.HostCallback) !*vst2.A
         .getParameter = getParameter,
         .num_programs = 0,
         .num_params = @intCast(self.plugin.param_info.len),
-        .num_inputs = 2,
-        .num_outputs = 2,
+        .num_inputs = @intCast(plugin.num_channels),
+        .num_outputs = @intCast(plugin.num_channels),
         .flags = .{
             .HasStateChunk = true,
             .HasReplacing = true,
@@ -521,5 +520,5 @@ pub fn deinit(self: *VstPlugin, alloc: std.mem.Allocator) void {
 }
 
 export fn VSTPluginMain(callback: vst2.HostCallback) callconv(.c) ?*anyopaque {
-    return init(allocator, callback) catch return null;
+    return init(callback) catch return null;
 }


### PR DESCRIPTION
- Fix previous use of `usingnamespace` to propagate drawing stuff
- Refactor building to use a .zon config file
- Define a list of plugin formats rather than as a CLI option
- Refactor gui initialization to come from plugin's interface
- `arbor.init()` now takes a struct of options
- Various little tweaks to get up to speed